### PR TITLE
Add blank-space to App generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [e2b_Fragments](https://fragments.e2b.dev/) — Platform for building and deploying AI-powered applications with sandboxed environments.
 - [Bolt.new](https://bolt.new) — AI-powered web development agent that allows you to prompt, run, edit, and deploy full-stack applications directly in the browser using WebContainers. Supports npm packages, Node.js servers, and third-party APIs.
 - [Bolt.diy](https://github.com/stackblitz-labs/bolt.diy) — Open source version of Bolt.new that supports multiple LLM providers including Groq, Anthropic, Ollama, OpenRouter, Gemini, LMStudio, Mistral, xAI, HuggingFace, DeepSeek
+- [blank-space](https://www.blankspace.build/) — Open-source AI app builder. Alternative to v0, Lovable, and Bolt. [Source](https://github.com/BrandeisPatrick/blank-space)
 - [Srcbook](https://github.com/srcbookdev/srcbook) — TypeScript-centric app development platform with an AI app builder and TypeScript notebook.
 - [Capacity](https://capacity.so) — AI powered full-stack web app development that turn prompt in natural language into fully functional web applications.
 - [Lovable](https://lovable.dev/) — AI-powered full-stack app development platform that converts natural language descriptions or designs into fully functional applications with built-in deployment and GitHub integration.


### PR DESCRIPTION
## Summary

Adding [blank-space](https://www.blankspace.build/), an open-source AI app builder that serves as an alternative to v0, Lovable, and Bolt.

## Details

- **Repository**: https://github.com/BrandeisPatrick/blank-space
- **Website**: https://www.blankspace.build/
- **Description**: An open-source AI app builder alternative to v0, Lovable, and Bolt
- **Tech Stack**: JavaScript, React
- **Topics**: AI agent, AI app builder, LLM, React, Vercel

This tool fits well in the "App generators" section alongside similar tools like Bolt.new, Lovable, and v0.