### PR TITLE
Add Conduit8 - CLI registry for Claude Code skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [poorcoder](https://github.com/vgrichina/poorcoder) — A collection of Bash scripts to extract code context, apply changes from markdown, and generate AI commit messages while using web-based LLMs.
 - [Vibe Compiler (vibec)](https://github.com/Strawberry-Computer/vibe-compiler) — A self-compiling tool that transforms markdown-based prompt stacks into code and tests using LLM generation. Works with any LLM via OpenRouter, including Claude, ChatGPT, and Grok.
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands (ei.: `ai Tell me the free space on disk`)
-- [Conduit8](https://github.com/alexander-zuev/conduit8) — CLI registry for discovering, installing, and managing Claude Code skills. Search 20+ curated skills by keyword or category, install directly to ~/.claude/skills/ with one command.
+- [Conduit8](https://github.com/conduit8/conduit8) — CLI registry for discovering, installing, and managing Claude Code skills. Search 20+ curated skills by keyword or category, install directly to ~/.claude/skills/ with one command.
 
 ### Desktop
 


### PR DESCRIPTION
## Description

Adds [Conduit8](https://github.com/conduit8/conduit8) to the Command-line tools section.

## What is Conduit8?

Conduit8 is a CLI registry for discovering, installing, and managing Claude Code skills. It provides:
- Search 20+ curated skills by keyword or category
- One-command installation directly to ~/.claude/skills/
- CLI-based skill management (list, remove)

## Category

Added to: **Command-line** tools section

## Installation

```bash
npx conduit8 search skills
npx conduit8 install skill <name>
```

## License

AGPL-3.0