### PR TITLE
Add Agentic Sprint to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Fine](https://fine.dev/?ref=awesome) — AI Dev Environment for automating mundane work. Integrate GitHub, Sentry, Linear. Get context-aware answers to questions. Plan, design and implement changes. Automate self-healing CI/CD.
 - [Potpie](https://potpie.ai) — Open Source AI Agents for your codebase in minutes. Use pre-built agents for Q&A, Testing, Debugging and System Design or create your own purpose-built agents.
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) - Anthropic's agentic coding tool.
+- [Agentic Sprint](https://github.com/damienlaine/agentic-sprint) — Spec-driven, self-iterative multi-agent framework for Claude Code with coordinated specialized agents (Python, Next.js, CI/CD, QA, UI Testing).
 - [Leap.new](https://leap.new/) - It builds functional apps with real backend services, APIs, and deploys to your cloud.
 
 ## PR agents


### PR DESCRIPTION
Adding **Agentic Sprint** - a spec-driven, self-iterative multi-agent framework for Claude Code.

It turns Claude Code into an autonomous development team with a Project Architect coordinating specialized agents (Python, Next.js, CI/CD, QA, UI Testing) through convergent sprints.

- Repository: https://github.com/damienlaine/agentic-sprint
- Website: https://damienlaine.github.io/agentic-sprint/
- License: MIT