### PR TITLE
Add Google Antigravity to IDE sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Testing](#testing)
 
 ## IDEs
-
+- [Google Antigravity](https://antigravity.google/) — An agent-first IDE that orchestrates autonomous AI agents to plan, execute, and verify complex coding tasks with deep browser integration.
 - [Crystal](https://github.com/stravu/crystal) — A new type of dev environment to manage, inspect, and test parallel Claude Code sessions.
 - [Cursor](https://www.cursor.com/) — An IDE with chat, edit, generate and debug features. Forked from VSCodium, so the interface is similar to VS Code. Uses OpenAI.
 - [PearAI](https://trypear.ai/) — An open source fork of VS Code with chat and inline code generation.


### PR DESCRIPTION
Antigravity is a significant new entry in the AI coding space, functioning as an "agent-first" IDE that forks VS Code to focus on autonomous agent orchestration rather than just code completion.

- Placed in the IDEs section.
- Verified the link points to the official landing page.
- Followed existing formatting conventions.