### PR TITLE
Add PraisonAI to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Roundtable MCP Server](https://github.com/askbudi/roundtable) — Zero-configuration MCP server that unifies multiple AI coding assistants through intelligent auto-discovery and standardized interface
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) - Anthropic's agentic coding tool.
 - [Agentic Sprint](https://github.com/damienlaine/agentic-sprint) — Spec-driven, self-iterative multi-agent framework for Claude Code with coordinated specialized agents (Python, Next.js, CI/CD, QA, UI Testing).
+- [PraisonAI](https://github.com/MervinPraison/PraisonAI) — Production-ready Multi-AI Agents framework with self-reflection. Fastest agent instantiation (3.77μs), 100+ LLM support, MCP integration, agentic workflows (route/parallel/loop/repeat), Python & JS SDKs.
 - [Leap.new](https://leap.new/) - It builds functional apps with real backend services, APIs, and deploys to your cloud.
 - [Recurse ML](https://recurse.ml) - Find bugs in AI Generated Code
 


### PR DESCRIPTION
## Adding PraisonAI

[PraisonAI](https://github.com/MervinPraison/PraisonAI) is a production-ready Multi-AI Agents framework with self-reflection.

### Key Features:
- **Fastest agent instantiation** (3.77μs) - benchmarked against CrewAI, LangGraph, PydanticAI
- **100+ LLM support** via LiteLLM (OpenAI, Anthropic, Gemini, Ollama, Groq, etc.)
- **MCP Protocol support** for seamless tool integration
- **Agentic workflows** with route(), parallel(), loop(), repeat() patterns
- **Built-in memory** (short-term, long-term, entity, episodic)
- **Self-reflection** for improved agent responses
- **Both Python & JavaScript SDKs**

### Simple Example:
```python
from praisonaiagents import Agent
agent = Agent(instructions="You are a helpful assistant")
agent.start("Write a haiku about AI")
```

- **GitHub**: https://github.com/MervinPraison/PraisonAI
- **Documentation**: https://docs.praison.ai

Thank you!