### PR TITLE
Add Baz CLI and Baz to the tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [cmd-ai](https://github.com/BrodaNoel/cmd-ai) - Turns natural language into executable shell commands (ei.: `ai Tell me the free space on disk`)
 - [promptext](https://github.com/1broseidon/promptext) — Smart code context extractor for AI assistants with accurate token counting, relevance prioritization, and budget management. Prepares optimized code context within LLM token limits.
 - [Conduit8](https://github.com/conduit8/conduit8) — CLI registry for discovering, installing, and managing Claude Code skills. Search 20+ curated skills by keyword or category, install directly to ~/.claude/skills/ with one command.
+- [Baz CLI](https://github.com/baz-scm/baz-cli) - CLI for AI assisted code review, with access to the actual code, diff etc.
 
 ### Desktop
 
@@ -168,6 +169,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Callstack.ai Code Reviewer](https://callstack.ai/code-reviewer) — AI-powered PR reviewer for GitHub, designed to identify bugs, security issues, and performance bottlenecks.
 - [Matter AI](https://matterai.dev) - Open Source AI Code Reviewer to help engineering teams release code with confidence.
 - [Gito](https://github.com/Nayjest/Gito) - AI code reviewer that works with any language model, locally or in GitHub Actions.
+- [Baz](https://baz.co) - Ai Code Reviewer that is tailored to your team's guidelines and conventions. Customizable, adaptable, responsive and integrated with the rest of teh developer tooling for context.
 
 ## App generators
 


### PR DESCRIPTION
Baz is a rather new entrant to the code review space.
* Placed in the PR Agents section
* Also attached the OSS AI-assisted code review CLI to the CLI tools list