### PR TITLE
Add Blank Space to App generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [ScrollHub](https://hub.scroll.pub/) — Generate and publish websites using the Scroll programming language.
 
 - [Berrry](https://berrry.app) — Twitter app generator that transforms social media posts into functional web applications. Turn tweets and Reddit content into complete apps with unique subdomains.
+- [Blank Space](https://www.blankspace.build/) — Open-source AI app builder for creating web applications using natural language. Self-hostable alternative to v0, Lovable, and Bolt.
 
 ## UI generators
 


### PR DESCRIPTION
Adding Blank Space to the App generators section.

- Open-source (Apache-2.0) AI app builder
- Self-hostable alternative to v0, Lovable, and Bolt
- Follows existing formatting conventions

Website: https://www.blankspace.build/
Source: https://github.com/BrandeisPatrick/blank-space