### PR TITLE
Add Havoptic - AI coding tool release tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Search](#search)
 - [Testing](#testing)
 - [Evaluation](#evaluation)
+- [Resources](#resources)
 
 ## IDEs
 - [Google Antigravity](https://antigravity.google/) — An agent-first IDE that orchestrates autonomous AI agents to plan, execute, and verify complex coding tasks with deep browser integration.
@@ -242,7 +243,6 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Bloop](https://bloop.ai/) — Natural language search for repositories.
 - [Buildt](https://www.buildt.ai/) — Natural language search for repositories. Waitlist.
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
-- [Havoptic](https://havoptic.com/) — Free, open-source timeline tracking releases from AI coding tools. Auto-updated daily. [Source](https://github.com/scotthavird/havoptic.com)
 
 ## Testing
 
@@ -263,3 +263,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 ## Evaluation
 
 - [sniffbench](https://github.com/AnswerLayer/sniffbench) — Benchmark suite for evaluating coding agents. Compare configurations, track metrics, and A/B test with real issues from your repos.
+
+## Resources
+
+- [Havoptic](https://havoptic.com/) — Free, open-source timeline tracking releases from AI coding tools. Auto-updated daily. [Source](https://github.com/scotthavird/havoptic.com)


### PR DESCRIPTION
## Add Havoptic

Adding Havoptic to the Search section.

**Website:** https://havoptic.com  
**Repository:** https://github.com/scotthavird/havoptic.com  
**License:** MIT

**Description:** A free, open-source timeline that tracks releases from AI coding tools. Auto-updated daily via GitHub Actions.

**Why it fits this list:** Helps developers stay updated on new releases from AI dev tools - useful for discovering what's new across the ecosystem.