### PR TITLE
Add ContextMCP to Search section

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Bloop](https://bloop.ai/) — Natural language search for repositories.
 - [Buildt](https://www.buildt.ai/) — Natural language search for repositories. Waitlist.
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
+- [ContextMCP](https://contextmcp.ai) — Self-hosted semantic search across documentation from various sources for AI agents.
 
 ## Testing
 


### PR DESCRIPTION
Added ContextMCP - a self-hosted MCP server that indexes documentation from various sources and serves it to AI Agents with semantic search.

GitHub Repository: https://github.com/dodopayments/context-mcp
Website: https://contextmcp.ai