### PR TITLE
Add Hashnet MCP to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Micro Agent by Builder](https://www.builder.io/blog/micro-agent) — An AI agent that writes and fixes code for you.
 - [Fine](https://fine.dev/?ref=awesome) — AI Dev Environment for automating mundane work. Integrate GitHub, Sentry, Linear. Get context-aware answers to questions. Plan, design and implement changes. Automate self-healing CI/CD.
 - [Potpie](https://potpie.ai) — Open Source AI Agents for your codebase in minutes. Use pre-built agents for Q&A, Testing, Debugging and System Design or create your own purpose-built agents.
+- [Hashnet MCP](https://github.com/hol-org/hashnet-mcp) — MCP server for AI agent discovery across multiple registries (NANDA, MCP, Virtuals, A2A, OpenRouter) via Registry Broker.
 - [Roundtable MCP Server](https://github.com/askbudi/roundtable) — Zero-configuration MCP server that unifies multiple AI coding assistants through intelligent auto-discovery and standardized interface
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) - Anthropic's agentic coding tool.
 - [Agentic Sprint](https://github.com/damienlaine/agentic-sprint) — Spec-driven, self-iterative multi-agent framework for Claude Code with coordinated specialized agents (Python, Next.js, CI/CD, QA, UI Testing).

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Micro Agent by Builder](https://www.builder.io/blog/micro-agent) — An AI agent that writes and fixes code for you.
 - [Fine](https://fine.dev/?ref=awesome) — AI Dev Environment for automating mundane work. Integrate GitHub, Sentry, Linear. Get context-aware answers to questions. Plan, design and implement changes. Automate self-healing CI/CD.
 - [Potpie](https://potpie.ai) — Open Source AI Agents for your codebase in minutes. Use pre-built agents for Q&A, Testing, Debugging and System Design or create your own purpose-built agents.
-- [Hashnet MCP](https://github.com/hol-org/hashnet-mcp) — MCP server for AI agent discovery across multiple registries (NANDA, MCP, Virtuals, A2A, OpenRouter) via Registry Broker.
+- [Hashnet MCP](https://github.com/hashgraph-online/hashnet-mcp-js) — MCP server for AI agent discovery across multiple registries (NANDA, MCP, Virtuals, A2A, OpenRouter) via Registry Broker.
 - [Roundtable MCP Server](https://github.com/askbudi/roundtable) — Zero-configuration MCP server that unifies multiple AI coding assistants through intelligent auto-discovery and standardized interface
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) - Anthropic's agentic coding tool.
 - [Agentic Sprint](https://github.com/damienlaine/agentic-sprint) — Spec-driven, self-iterative multi-agent framework for Claude Code with coordinated specialized agents (Python, Next.js, CI/CD, QA, UI Testing).


### PR DESCRIPTION
Adds Hashnet MCP to the Agents section.

Hashnet MCP is an MCP server for AI agent discovery across multiple registries (NANDA, MCP, Virtuals, A2A, OpenRouter) via Registry Broker.

- GitHub: https://github.com/hashgraph-online/hashnet-mcp-js
- License: Apache 2.0