### PR TITLE
Add Open Agent to the Agents list

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Potpie](https://potpie.ai) — Open Source AI Agents for your codebase in minutes. Use pre-built agents for Q&A, Testing, Debugging and System Design or create your own purpose-built agents.
 - [Roundtable MCP Server](https://github.com/askbudi/roundtable) — Zero-configuration MCP server that unifies multiple AI coding assistants through intelligent auto-discovery and standardized interface
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) - Anthropic's agentic coding tool.
+- [Open Agent](https://github.com/Th0rgal/openagent) — Self-hosted control plane for Claude Code with isolated container workspaces and real-time mission streaming.
 - [Agentic Sprint](https://github.com/damienlaine/agentic-sprint) — Spec-driven, self-iterative multi-agent framework for Claude Code with coordinated specialized agents (Python, Next.js, CI/CD, QA, UI Testing).
 - [Leap.new](https://leap.new/) - It builds functional apps with real backend services, APIs, and deploys to your cloud.
 - [Recurse ML](https://recurse.ml) - Find bugs in AI Generated Code


### PR DESCRIPTION
## Summary

Adding [Open Agent](https://github.com/Th0rgal/openagent) to the Agents section.

Open Agent is a self-hosted control plane for Claude Code that provides:
- **Isolated container workspaces** using systemd-nspawn for secure execution
- **Real-time mission streaming** with full event visibility
- **Git-backed Library** for managing skills, tools, rules, and MCPs
- **Web and iOS dashboards** for mission management

Built with Rust/Axum backend and Apache 2.0 licensed.