### PR TITLE
Add Raysurfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Open Agent](https://github.com/Th0rgal/openagent) — Self-hosted control plane for Claude Code with isolated container workspaces and real-time mission streaming.
 - [Agentic Sprint](https://github.com/damienlaine/agentic-sprint) — Spec-driven, self-iterative multi-agent framework for Claude Code with coordinated specialized agents (Python, Next.js, CI/CD, QA, UI Testing).
 - [Leap.new](https://leap.new/) - It builds functional apps with real backend services, APIs, and deploys to your cloud.
+- [Raysurfer](https://raysurfer.com/) — LLM output caching and reuse infrastructure for AI coding agents. Python ([raysurfer](https://pypi.org/project/raysurfer/)) and TypeScript ([raysurfer](https://www.npmjs.com/package/raysurfer)) SDKs. Delivers cached outputs up to 30x faster.
 - [Recurse ML](https://recurse.ml) - Find bugs in AI Generated Code
 
 ## PR agents


### PR DESCRIPTION
## Summary

- Adds [Raysurfer](https://raysurfer.com/) to the **Agents** section — LLM output caching and reuse infrastructure for AI coding agents
- Python ([raysurfer](https://pypi.org/project/raysurfer/)) and TypeScript ([raysurfer](https://www.npmjs.com/package/raysurfer)) SDKs available
- Delivers cached outputs up to 30x faster by retrieving and reusing similar results instead of regenerating them