### PR TITLE
Add VibeBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Claude Code](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview) - Anthropic's agentic coding tool.
 - [Open Agent](https://github.com/Th0rgal/openagent) — Self-hosted control plane for Claude Code with isolated container workspaces and real-time mission streaming.
 - [Agentic Sprint](https://github.com/damienlaine/agentic-sprint) — Spec-driven, self-iterative multi-agent framework for Claude Code with coordinated specialized agents (Python, Next.js, CI/CD, QA, UI Testing).
+- [VibeBox](https://vibebox.robcholz.com) — Open-source, per-project micro-VM sandbox for running AI coding agents safely on macOS.
 - [Leap.new](https://leap.new/) - It builds functional apps with real backend services, APIs, and deploys to your cloud.
 - [Recurse ML](https://recurse.ml) - Find bugs in AI Generated Code
 


### PR DESCRIPTION
Hi! I'd like to add VibeBox to this list.

VibeBox is an open-source Rust CLI that creates a per-repo Linux micro-VM sandbox on macOS (Apple Silicon) using Apple’s Virtualization Framework. It’s designed for fast warm re-entry, reusable sessions (attach/reuse, multiple terminals), and explicit mounts (repo-only by default; opt-in allowlist for anything else).

GitHub: https://github.com/robcholz/vibebox
Free and open source