### PR TITLE
Add EkLine to Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,9 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [DiagramGPT](https://www.eraser.io/diagramgpt) — DiagramGPT is a free AI-based web app that converts a schema, infrastructure definition, code snippet or plain language description into diagrams. The tool can generate flow charts, entity relationship diagrams, cloud architecture diagrams and sequence diagrams.
 - [DocuWriter.ai](https://www.docuwriter.ai/) — AI-powered web app to generate automated Code & API documentation from your source code files.
 - [README-AI](https://github.com/eli64s/readme-ai) — Automated README.md file generator, powered by large language model APIs.
-- [Supacodes](https://www.supacodes.com) — An AI tool that automates writing & updating code documentation in Github
-- [CodexAtlas](https://codedocumentation.app/) — Automated code and API documentation using latest AI models
+- [Supacodes](https://www.supacodes.com) — An AI tool that automates writing & updating code documentation in Github.
+- [CodexAtlas](https://codedocumentation.app/) — Automated code and API documentation using latest AI models.
+- [EkLine](https://ekline.io/) — Helps software teams create and maintain high-quality documentation with AI-powered quality checks, style guide enforcement, and automatic doc generation.
 
 ## Observability
 - [TraceRoot AI](https://traceroot.ai/) - An AI native observability tool that using AI agents to automatically fix your production bugs.


### PR DESCRIPTION
 Hi! I'd like to add EkLine to the Documentation section.

   **EkLine** (https://ekline.io) is an AI-powered documentation review tool that:
   - Runs in CI/CD pipelines (GitHub Actions, GitLab CI).
   - Catches style guide violations, broken links, and terminology inconsistencies.
   - Uses AI to detect documentation that may be outdated relative to code changes.

   It fits well alongside the other documentation tools in this list.

Website: https://ekline.io/
Docs: https://docs.ekline.io