### PR TITLE
Add PM Skills - Product management skill library for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Leap.new](https://leap.new/) - It builds functional apps with real backend services, APIs, and deploys to your cloud.
 - [Recurse ML](https://recurse.ml) - Find bugs in AI Generated Code
 - [Trellis](https://github.com/mindfold-ai/Trellis) - All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
+- [PM Skills](https://github.com/product-on-purpose/pm-skills) — A library of 24 plug-and-play product management skills for Claude Code following the agentskills.io specification, covering the full product lifecycle from discovery through delivery.
 
 ## PR agents
 


### PR DESCRIPTION
## Description

Adding [PM Skills](https://github.com/product-on-purpose/pm-skills) to the Agents section.

## What is PM Skills?

PM Skills is a curated library of 24 plug-and-play product management skills for Claude Code,
following the [agentskills.io specification](https://agentskills.io/specification). It provides:

- 24 structured skills across 6 Triple Diamond phases (Discover, Define, Develop, Deliver, Measure, Iterate)
- Ready-to-use templates and workflow bundles for the full product lifecycle
- Follows the open agentskills.io standard for agent skill interoperability

## Why it fits this list

PM Skills extends Claude Code (already listed in Agents) with structured product management
workflows. Similar to how Trellis adds task management and Conduit8 adds skill discovery,
PM Skills adds domain-specific agent skills that produce technical artifacts (PRDs, architecture
specs, delivery plans) used directly in development workflows.

## Category

Added to: **Agents** section

## Links

- **GitHub**: https://github.com/product-on-purpose/pm-skills
- **Specification**: https://agentskills.io/specification
- **License**: Apache-2.0