### PR TITLE
Add Frontman to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Recurse ML](https://recurse.ml) - Find bugs in AI Generated Code
 - [Zenable](https://zenable.io/) — AI guardrails that learn your team's standards and ensure coding agents follow them, maximizing speed and quality.
 - [Trellis](https://github.com/mindfold-ai/Trellis) - All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
-- [Frontman](https://frontman.dev/) — Open-source AI coding agent that lives in your browser. Click any element, describe changes in plain English, get real code edits with hot reload. Supports Next.js, Vite (React, Vue, Svelte), and Astro. [Source](https://github.com/frontman-ai/frontman)
+- [Frontman](https://frontman.sh/) — Open-source AI coding agent that lives in your browser. Click any element, describe changes in plain English, get real code edits with hot reload. Supports Next.js, Vite (React, Vue, Svelte), and Astro. [Source](https://github.com/frontman-ai/frontman)
 
 ## PR agents
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Recurse ML](https://recurse.ml) - Find bugs in AI Generated Code
 - [Zenable](https://zenable.io/) — AI guardrails that learn your team's standards and ensure coding agents follow them, maximizing speed and quality.
 - [Trellis](https://github.com/mindfold-ai/Trellis) - All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
+- [Frontman](https://frontman.dev/) — Open-source AI coding agent that lives in your browser. Click any element, describe changes in plain English, get real code edits with hot reload. Supports Next.js, Vite (React, Vue, Svelte), and Astro. [Source](https://github.com/frontman-ai/frontman)
 
 ## PR agents
 


### PR DESCRIPTION
## Summary

- Adds [Frontman](https://frontman.sh/) to the **Agents** section — an open-source AI coding agent that runs in the browser with click-to-edit and hot reload support for Next.js, Vite (React, Vue, Svelte), and Astro.
- Entry follows the existing list format with website link and source repository link.