### PR TITLE
Add awesome-code-docs to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,4 +279,5 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 
 ## Resources
 
+- [Awesome Code Docs](https://github.com/johnxie/awesome-code-docs) — Curated deep-dive tutorials for open-source AI and developer tooling projects.
 - [Havoptic](https://havoptic.com/) — Free, open-source timeline tracking releases from AI coding tools. Auto-updated daily. [Source](https://github.com/scotthavird/havoptic.com)


### PR DESCRIPTION
## Summary
- Adds [Awesome Code Docs](https://github.com/johnxie/awesome-code-docs) to the **Resources** section

Follows up on #207 — moved to Resources per maintainer feedback. Apologies for the delay!