### PR TITLE
Add agent-media to Command-line assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 ### Command-line
 
 - [Amazon Q Developer CLI](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html?trk=fd6bb27a-13b0-4286-8269-c7b1cfaa29f0&sc_channel=el) - CLI that provides command completion, command translation using generative AI to translate intent to commands, and a full agentic chat interface with context management that helps you write code. It works with many terminals and shells, on MacOS, Linux and Windows (via wsl).
+- [agent-media](https://github.com/yuvalsuede/agent-media) — CLI tool and MCP server for AI video and image generation. Unified access to 7 models (Kling, Veo, Sora, Seedance, Flux, Grok Imagine) with 27 commands. Also exposes 9 MCP tools for Claude Code integration.
 - [aloc](https://github.com/modern-tooling/aloc) — A modern, AI-augmented lines of code counter built with Rust and Ratatui. Uses AI effort profiles for accurate project estimation.
 - [talk-codebase](https://github.com/rsaryev/talk-codebase) — CLI chatbot with repository as context. Supports OpenAI as well as locally running LLMs via GPT4All.
 - [gptcomet](https://github.com/belingud/gptcomet) — CLI tool to help you generate commit message and review changes. Support mutiple providers and languages.


### PR DESCRIPTION
## Summary
- Adds [agent-media](https://github.com/yuvalsuede/agent-media), a CLI tool and MCP server for AI video and image generation
- Unified access to 7 models: Kling 3.0 Pro, Veo 3.1, Sora 2 Pro, Seedance 1.0 Pro, Flux 2 Pro, Flux 2 Flex, Grok Imagine
- 27 CLI commands for generating, managing, and browsing media
- Also works as an MCP server with 9 tools for Claude Code integration
- Install via npm: `npm install -g agent-media-cli`
- Open source (Apache-2.0)