### PR TITLE
Add changelog-gen: AI-powered changelog generator (Claude)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This is a curated list of AI-powered developer tools. These tools leverage AI to assist developers in tasks such as code completion, refactoring, debugging, documentation, and more.
 
+- [changelog-gen](https://github.com/indoor47/changelog-gen) - AI-powered changelog generator that converts git commits into human-readable release notes using Claude
 - [IDEs](#ides)
 - [Git Clients](#git-clients)
 - [Assistants](#assistants)


### PR DESCRIPTION
Hi! I'd like to add **changelog-gen** to the list.

**[changelog-gen](https://github.com/indoor47/changelog-gen)** — AI-powered changelog generator that converts raw git commits into clean, human-readable release notes using Claude.

- Runs `git log --oneline --no-merges` on any repo
- Groups commits into Features / Bug Fixes / Performance / Refactoring / Chores
- Rewrites terse messages into plain English  
- Outputs markdown in ~5 seconds, ~$0.001 per run

```bash
python changelog_gen.py --repo . --since v1.2.0 --out CHANGELOG.md
```

Open source, MIT license. Happy to adjust the description or placement.