### PR TITLE
Add NeuroLink - TypeScript-first AI SDK by Juspay

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Recurse ML](https://recurse.ml) - Find bugs in AI Generated Code
 - [Zenable](https://zenable.io/) — AI guardrails that learn your team's standards and ensure coding agents follow them, maximizing speed and quality.
 - [Trellis](https://github.com/mindfold-ai/Trellis) - All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
-- [NeuroLink](https://github.com/juspay/neurolink) — Open-source TypeScript AI SDK for building AI-powered applications. Provides a unified API for 200+ models, RAG pipelines, AI agent orchestration, and built-in observability — designed for production use.
+- [NeuroLink](https://github.com/juspay/neurolink) — Open-source TypeScript AI SDK for building AI-powered applications. Provides a unified API for 100+ models, RAG pipelines, AI agent orchestration, and built-in observability — designed for production use.
 
 ## PR agents
 


### PR DESCRIPTION
## Description

This PR adds [NeuroLink](https://github.com/juspay/neurolink) to the Agents section.

**NeuroLink** is an open-source TypeScript AI SDK for building AI-powered applications. It provides a unified API for 13 major AI providers and 100+ models, RAG pipelines, AI agent orchestration, and built-in observability — designed for production use.

## Details

- **GitHub:** https://github.com/juspay/neurolink
- **License:** Apache 2.0
- **Language:** TypeScript
- **Built by:** Juspay

## Why it belongs here

NeuroLink is a production-ready TypeScript AI SDK that enables developers to build multi-step AI agents with tool calling, memory, and RAG capabilities through a type-safe API. It fits naturally in the Agents section alongside other frameworks that help developers build AI-powered developer tools.