### PR TITLE
Add Spiderhash to Testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 
 ## Testing
 
+- [Spiderhash](https://spiderhash.io/) — Webhook debugging and inspection platform for capturing, replaying, and troubleshooting webhook/API events with shareable request logs.
 - [Checksum AI](https://checksum.ai) — End-to-end fully autonomous QA Automation agent that generates CI/CD ready Playwright tests directly to the repository
 - [OctoMind](https://octomind.dev) — Auto-maintenance and generated browser-based end-to-end-tests integrated into Github Actions, Azure DevOps and more.
 - [Traceloop](https://traceloop.com/) — Uses OpenTelemetry tracing data with generative AI to improve system reliability.


### PR DESCRIPTION
Adds Spiderhash as a webhook debugging/testing tool in the Testing section.\n\nSpiderhash helps developers inspect, replay, and troubleshoot webhook/API events.