### PR TITLE
Add rule-gen to Snippet generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [AI Code Playground](https://aicodeplayground.com/) — A web tool for refactoring and improving code.
 - [AutoRegex](https://www.autoregex.xyz/) — AutoRegex uses OpenAI's GPT-3 to produce regular expressions from plain English.
 - [unpkg.ai](https://unpkg.ai/) — Open source AI-powered ESM module generation service. Generate JavaScript modules via URL for rapid prototyping.
+- [rule-gen](https://github.com/nedcodes-ok/rule-gen) — CLI tool that generates AI coding rules from your actual codebase using Google Gemini. Feeds source files into Gemini's 1M token context window to produce project-specific rules for Cursor, Claude Code, Copilot, and Windsurf. Zero dependencies.
 
 ## Documentation
 


### PR DESCRIPTION
Adds [rule-gen](https://github.com/nedcodes-ok/rule-gen) — a CLI tool that generates AI coding rules from your actual codebase using Google Gemini's 1M token context window.

Supports Cursor (.mdc), Claude Code (CLAUDE.md), GitHub Copilot, and Windsurf output formats. Zero dependencies.

npm: `npm install -g rulegen-ai`