### PR TITLE
Add 'git-lrc' to Git Clients section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 
 ## Git Clients
 
-- [git-lrc](https://github.com/HexmosTech/git-lrc) - Free, Unlimited AI Code Reviews That Run on Every Commit.
+- [git-lrc](https://github.com/HexmosTech/git-lrc) - Free, unlimited AI code reviews that run on every commit.
 - [GitBrain](https://gitbrain.dev/) — Git client that simplifies the git workflow. Splits code changes, generates summaries & commit messages for code changes. Uses OpenAI.
 - [GitButler](https://gitbutler.com/) — Git client for simultaneous branches on top of your existing workflow. Defaults to OpenAI, can be changed to Perplexity for generating conventional commit messages.
 - [AI Git Narrator](https://github.com/pmusolino/AI-Git-Narrator) - CLI tool that uses AI to automatically generate high-quality Git commit messages and pull request descriptions.


### PR DESCRIPTION
We just launched our project on GitHub — **git-lrc**.

**It runs AI code reviews just before every commit**. Completely free. No limits.

We recently hit [#3 Product of the Day on Product Hunt](https://www.producthunt.com/products/git-lrc?launch=git-lrc), which was a huge push from the community.

The goal is simple: make AI code review engineer-centric and accessible to every developer.

Would really appreciate it if you could take a look. 
And if you like what we’re building, 
please drop a ⭐ on GitHub and accept the PR— that early support genuinely makes a difference.

[https://github.com/HexmosTech/git-lrc](https://github.com/HexmosTech/git-lrc)

Thanks a ton :)