### PR TITLE
Add pixelmuse to Command-line section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [rule-porter](https://github.com/nedcodes-ok/rule-porter) — Zero-dependency CLI that converts AI IDE rule files between Cursor (.mdc), CLAUDE.md, AGENTS.md, Copilot, and Windsurf. Bidirectional with lossy-conversion warnings.
 - [Claude Code Open](https://github.com/kill136/claude-code-open) — Open-source AI coding platform with Web IDE, multi-agent system, 37+ tools, and MCP protocol support. Features browser-based IDE with Monaco editor, Blueprint multi-agent orchestration, and scheduled task daemon.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [pixelmuse](https://github.com/starmorph/pixelmuse-cli) — AI image generation from the terminal with 6 models (Flux, Imagen 3, Recraft V4, Nano Banana). CLI, interactive TUI, and MCP server for AI agents.
 
 ### Desktop
 


### PR DESCRIPTION
Adds [pixelmuse](https://github.com/starmorph/pixelmuse-cli) to the Command-line assistants section.

AI image generation from the terminal with 6 models (Flux, Imagen 3, Recraft V4, Nano Banana). Ships as a CLI, interactive TUI, and MCP server for AI agents like Claude Code, Cursor, and Windsurf.

- npm: https://www.npmjs.com/package/pixelmuse
- License: BSL 1.1