### PR TITLE
Add dna-claude-analysis to Command-line section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [rule-porter](https://github.com/nedcodes-ok/rule-porter) — Zero-dependency CLI that converts AI IDE rule files between Cursor (.mdc), CLAUDE.md, AGENTS.md, Copilot, and Windsurf. Bidirectional with lossy-conversion warnings.
 - [Claude Code Open](https://github.com/kill136/claude-code-open) — Open-source AI coding platform with Web IDE, multi-agent system, 37+ tools, and MCP protocol support. Features browser-based IDE with Monaco editor, Blueprint multi-agent orchestration, and scheduled task daemon.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
+- [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) — Personal genome analysis toolkit that uses Claude to analyze raw DNA data across 17 categories (ancestry, health risks, nutrition, fitness, pharmacogenomics, and more) and generates a terminal-style HTML visualization via CLI.
 
 ### Desktop
 


### PR DESCRIPTION
Adds [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the **Command-line** section under Assistants.

**What it does:** Personal genome analysis toolkit that uses Claude to analyze raw DNA data across 17 categories — ancestry, health risks, nutrition, fitness, sleep, pharmacogenomics, carrier status, and more. Outputs markdown reports and generates a terminal-style single-page HTML visualization, all driven from the command line.

**Why it fits here:** It is a CLI-driven tool that leverages an AI model (Claude) as the core analysis engine, fitting naturally alongside other command-line AI developer tools in this list.