### PR TITLE
Add LynxPrompt to Command-line section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Tokscale](https://github.com/junhoyeo/tokscale) — CLI tool for tracking token usage from AI coding agents (OpenCode, Claude Code, OpenClaw, Codex, Gemini CLI, Cursor IDE, AmpCode, Factory Droid) with a global leaderboard and 2D/3D contribution graphs.
 - [vsync](https://github.com/nicepkg/vsync) — CLI tool that syncs Skills, MCP servers, Agents & Commands across Claude Code, Cursor, OpenCode, and Codex with automatic format conversion (JSON ↔ TOML ↔ JSONC).
 - [rule-porter](https://github.com/nedcodes-ok/rule-porter) — Zero-dependency CLI that converts AI IDE rule files between Cursor (.mdc), CLAUDE.md, AGENTS.md, Copilot, and Windsurf. Bidirectional with lossy-conversion warnings.
+- [LynxPrompt](https://github.com/GeiserX/LynxPrompt) — Self-hostable platform for managing AI IDE configuration files. Generates, syncs, and shares configs (.cursorrules, CLAUDE.md, copilot-instructions.md, etc.) across 30+ AI coding assistants via web UI, REST API, CLI, and federated blueprint marketplace.
 - [Claude Code Open](https://github.com/kill136/claude-code-open) — Open-source AI coding platform with Web IDE, multi-agent system, 37+ tools, and MCP protocol support. Features browser-based IDE with Monaco editor, Blueprint multi-agent orchestration, and scheduled task daemon.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
 


### PR DESCRIPTION
## Add LynxPrompt

**Name:** [LynxPrompt](https://github.com/GeiserX/LynxPrompt)  
**Website:** [lynxprompt.com](https://lynxprompt.com)  
**License:** GPL-3.0  

### What is LynxPrompt?

LynxPrompt is a self-hostable platform for managing AI IDE configuration files. It generates, syncs, and shares configs (`.cursorrules`, `CLAUDE.md`, `copilot-instructions.md`, etc.) across 30+ AI coding assistants via web UI, REST API, CLI, and a federated blueprint marketplace.

### Why Command-line section?

LynxPrompt includes a CLI component and fits alongside peers like **vsync** (syncs AI IDE configs across tools), **rule-porter** (converts AI IDE rule files between formats), and **Conduit8** (CLI registry for Claude Code skills) — all tools in the Command-line section that manage AI coding assistant configurations.

### Tech Stack

Next.js, PostgreSQL, Docker Compose