### PR TITLE
Add Azeth MCP Server to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Recurse ML](https://recurse.ml) - Find bugs in AI Generated Code
 - [Zenable](https://zenable.io/) — AI guardrails that learn your team's standards and ensure coding agents follow them, maximizing speed and quality.
 - [Trellis](https://github.com/mindfold-ai/Trellis) - All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
+- [Azeth MCP Server](https://github.com/azeth-protocol/mcp-server) — MCP server providing trust infrastructure tools for AI agents: smart accounts, x402 payments, on-chain reputation, and service discovery.
 
 ## PR agents
 


### PR DESCRIPTION
Adds [Azeth MCP Server](https://github.com/azeth-protocol/mcp-server) to the Agents section.

Azeth MCP Server provides trust infrastructure tools for AI agents via the Model Context Protocol:
- Smart account creation and management (ERC-4337)
- x402 HTTP-native payments between agents
- On-chain reputation scoring and service discovery
- Payment agreements for recurring agent-to-agent transactions

npm: `@azeth/mcp-server`
GitHub: https://github.com/azeth-protocol/mcp-server