### PR TITLE
Add agentskill.sh to search tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Buildt](https://www.buildt.ai/) — Natural language search for repositories. Waitlist.
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextMCP](https://contextmcp.ai) — Self-hosted semantic search across documentation from various sources for AI agents.
+- [AgentSkill.sh](https://agentskill.sh) — Browse and install 69,000+ AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.
 
 ## Testing
 


### PR DESCRIPTION
Adds [agentskill.sh](https://agentskill.sh) to the Search section.

agentskill.sh is a directory of 69,000+ AI agent skills with one-click install for Claude Code, Cursor, Copilot, Windsurf, Zed, and 20+ AI tools.