### PR TITLE
Add BGPT MCP (scientific paper search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Buildt](https://www.buildt.ai/) — Natural language search for repositories. Waitlist.
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextMCP](https://contextmcp.ai) — Self-hosted semantic search across documentation from various sources for AI agents.
+- [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) — Search scientific papers and retrieve structured experimental data from full-text studies via MCP.
 
 ## Testing
 


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) — a hosted MCP server for searching scientific papers and retrieving structured experimental data from full-text studies.

- **Endpoints:** SSE and Streamable HTTP
- **Tool:** `search_papers` — returns methods, results, sample sizes, quality scores from full-text papers
- **Pricing:** 50 free searches, then $0.01/result