### PR TITLE
Add Stoneforge - multi-agent orchestration for AI coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Leap.new](https://leap.new/) - It builds functional apps with real backend services, APIs, and deploys to your cloud.
 - [Recurse ML](https://recurse.ml) - Find bugs in AI Generated Code
 - [Zenable](https://zenable.io/) — AI guardrails that learn your team's standards and ensure coding agents follow them, maximizing speed and quality.
+- [Stoneforge](https://stoneforge.ai) — Open-source orchestration for AI coding agents. Run multiple agents in parallel with automatic dispatch, merge, and recovery.
 - [Trellis](https://github.com/mindfold-ai/Trellis) - All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
 
 ## PR agents


### PR DESCRIPTION
Adds [Stoneforge](https://stoneforge.ai) to the Agents section.

Stoneforge is an open-source orchestration platform that enables running multiple AI coding agents in parallel with automatic task dispatch, merge conflict resolution, and error recovery.

- GitHub: https://github.com/stoneforge-ai/stoneforge
- Website: https://stoneforge.ai