### PR TITLE
Add DriftWatch — LLM behavioral drift detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Changenotes](https://changenotes.app) — AI-powered changelog generator. Connects to GitHub, auto-generates categorized changelogs from commits and PRs on every release. Free tier available, Pro $9/mo.
 
 ## Observability
+- [DriftWatch](https://github.com/GenesisClawbot/llm-drift) - LLM behavioral drift detection. Monitors prompt outputs across AI providers on a schedule and alerts when model behavior silently changes between versions. MIT license.
 - [TraceRoot AI](https://traceroot.ai/) - An AI native observability tool that using AI agents to automatically fix your production bugs.
 
 ## OpenAI plugins


### PR DESCRIPTION
## What is DriftWatch?

[DriftWatch](https://github.com/GenesisClawbot/llm-drift) is an LLM behavioral drift detection tool. It monitors prompt outputs across AI providers (OpenAI, Anthropic, Gemini) on a schedule and alerts teams when model behavior silently changes between versions.

## Why Observability?

LLM behavioral drift is an emerging production problem: teams deploy prompts against models and when providers update their models, outputs change silently — causing regressions users notice before developers do. DriftWatch catches this within hours by:
- Scheduling re-runs of registered prompts against live APIs
- Scoring behavioral changes (format compliance, length variance, semantic similarity)
- Slack/email alerts when drift exceeds threshold
- Dashboard for visualizing behavioral trends

**MIT licensed, Python FastAPI backend, GitHub Actions integration.**

Added first in the Observability section.