### PR TITLE
Add Octomind - session-based AI development assistant with MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Claude Code Open](https://github.com/kill136/claude-code-open) — Open-source AI coding platform with Web IDE, multi-agent system, 37+ tools, and MCP protocol support. Features browser-based IDE with Monaco editor, Blueprint multi-agent orchestration, and scheduled task daemon.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
 - [models](https://github.com/arimxyer/models) — A TUI for browsing AI models, benchmarks from Artificial Analysis, and coding agents with GitHub integration. Built with Rust and Ratatui.
+- [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
 
 ### Desktop
 


### PR DESCRIPTION
## Summary

This PR adds [Octomind](https://github.com/muvon/octomind) to the Command-line tools section.

## About Octomind

Octomind is a **session-based AI development assistant** written in Rust with:

- **Full MCP Protocol Support** - Implements the Model Context Protocol for tool integration
- **7 LLM Providers** - OpenRouter, OpenAI, Anthropic, Google, Amazon, Cloudflare, DeepSeek, and native Ollama support
- **Extensible Architecture** - Configure any agent as MCP tool via config
- **Plan-First Workflow** - Multi-step planning with validation gates
- **Semantic Code Search** - Via Octocode integration with GraphRAG
- **Persistent Memory** - Via Octobrain integration with knowledge graphs
- **Zero Provider Lock-in** - Switch providers instantly with `/model` command
- **Real-time Cost Tracking** - Track AI costs per session

## Entry Details

| Field | Value |
|-------|-------|
| GitHub | https://github.com/muvon/octomind |
| Website | https://muvon.io |
| License | Apache 2.0 |
| Type | CLI |
| Platforms | Linux, Windows, MacOS |
| Pricing | Free |
| Programming Languages | Rust |

## Checklist

- [x] Added to Command-line section (alphabetically after "models")
- [x] Consistent format with existing entries
- [x] All links verified
- [x] Description is concise and informative