### PR TITLE
Add WritBase to Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Zenable](https://zenable.io/) — AI guardrails that learn your team's standards and ensure coding agents follow them, maximizing speed and quality.
 - [Stoneforge](https://stoneforge.ai) — Open-source orchestration for AI coding agents. Run multiple agents in parallel with automatic dispatch, merge, and recovery.
 - [Trellis](https://github.com/mindfold-ai/Trellis) - All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
+- [WritBase](https://github.com/Writbase/writbase) — MCP-native task management control plane for AI agent fleets with multi-agent permissions, delegation safety, and webhook notifications.
 
 ## PR agents
 


### PR DESCRIPTION
## Summary
- Adds [WritBase](https://github.com/Writbase/writbase) to the Agents section
- WritBase is an MCP-native task management control plane for AI agent fleets with multi-agent permissions, delegation safety, and webhook notifications

## Entry
Inserted alphabetically at the end of the Agents section (after Trellis, before PR agents section).