### PR TITLE
Add TITAN to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Zenable](https://zenable.io/) — AI guardrails that learn your team's standards and ensure coding agents follow them, maximizing speed and quality.
 - [Stoneforge](https://stoneforge.ai) — Open-source orchestration for AI coding agents. Run multiple agents in parallel with automatic dispatch, merge, and recovery.
 - [Trellis](https://github.com/mindfold-ai/Trellis) - All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
+- [TITAN](https://github.com/Djtony707/TITAN) — Open-source autonomous AI agent framework with 149 tools, 34 LLM providers, P2P mesh networking, MCP server mode, sandbox code execution, RAG, and React dashboard. TypeScript, self-hosted, MIT licensed.
 
 ## PR agents
 


### PR DESCRIPTION
## Summary

Adding [TITAN](https://github.com/Djtony707/TITAN) to the Agents section.

TITAN is an open-source autonomous AI agent framework built with TypeScript/Node.js. It features 149 built-in tools, 34 LLM providers, P2P mesh networking, MCP server mode (expose tools to other agents via JSON-RPC), sandbox code execution, RAG with vector search, WebRTC voice via LiveKit, and a React dashboard. MIT licensed with 3,879 tests.

- **GitHub**: https://github.com/Djtony707/TITAN
- **npm**: https://www.npmjs.com/package/titan-agent
- **License**: MIT