### PR TITLE
Add ORCH — CLI AI agent runtime for coordinating AI teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Stoneforge](https://stoneforge.ai) — Open-source orchestration for AI coding agents. Run multiple agents in parallel with automatic dispatch, merge, and recovery.
 - [Trellis](https://github.com/mindfold-ai/Trellis) - All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
 
+- [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
+
 ## PR agents
 
 - [Greptile](https://greptile.com/code-review-bot) — AI bot that reviews PRs in GitHub/Gitlab with full context of the codebase.


### PR DESCRIPTION
## Add ORCH to the Agents section

[ORCH](https://github.com/oxgeneral/ORCH) is a CLI runtime that coordinates Claude Code, OpenCode (Codex/Gemini/Mistral), Cursor, and shell scripts as a typed AI engineering team.

**Why it fits here:**
- CLI-first AI agent orchestrator (TypeScript, Node.js)
- Agents execute tasks with a formal state machine: `todo → in_progress → review → done`
- Auto-retry on failure, inter-agent messaging, shared context store
- TUI dashboard (Ink/React) for real-time monitoring
- 5 adapters: claude, opencode, codex, cursor, shell
- 1,647 tests, strict TypeScript, MIT license
- Available as: `npm install -g @oxgeneral/orch`

**Entry added:**
```
- [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
```