### PR TITLE
Add llm.log to Observability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Claude Code Open](https://github.com/kill136/claude-code-open) — Open-source AI coding platform with Web IDE, multi-agent system, 37+ tools, and MCP protocol support. Features browser-based IDE with Monaco editor, Blueprint multi-agent orchestration, and scheduled task daemon.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
 - [models](https://github.com/arimxyer/models) — A TUI for browsing AI models, benchmarks from Artificial Analysis, and coding agents with GitHub integration. Built with Rust and Ratatui.
+- [llm.log](https://github.com/lanesket/llm.log) — Local MITM proxy with TUI dashboard for monitoring LLM API calls — token usage, real costs, latency and full request inspector. Supports OpenAI, Anthropic and OpenRouter. Zero code changes, single binary.
 
 ### Desktop
 


### PR DESCRIPTION
Adds [llm.log](https://github.com/lanesket/llm.log) to the Observability section.

llm.log is a local MITM proxy with TUI dashboard for monitoring LLM API calls — token usage, real costs, latency and full request inspector. Works via `HTTPS_PROXY` with zero code changes. Supports OpenAI, Anthropic and OpenRouter. Single binary, pure Go.