### PR TITLE
Add AI Developer Toolkit to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,3 +307,4 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Cursor Rules Collection](https://github.com/survivorforge/cursor-rules) — 35+ production-quality .cursorrules files for 16 frameworks including React, Next.js, Python, Go, Rust, SvelteKit, and Django. Configure AI coding assistants with code style, architecture, and testing conventions. MIT licensed.
 - [AI Coding Compare](https://aicodingcompare.com) — Compare 50+ AI coding assistants with features, pricing, and performance benchmarks.
 - [Havoptic](https://havoptic.com/) — Free, open-source timeline tracking releases from AI coding tools. Auto-updated daily. [Source](https://github.com/scotthavird/havoptic.com)
+- [AI Developer Toolkit](https://github.com/Money-Monkey-26/ai-dev-toolkit) — 32+ production-tested AI prompts for code review, security audit, debugging, testing, and architecture. Works with Claude Code, ChatGPT, Cursor, and any AI assistant.


### PR DESCRIPTION
## What

Adds [AI Developer Toolkit](https://github.com/Money-Monkey-26/ai-dev-toolkit) to the Resources section.

## Description

AI Developer Toolkit is a collection of 32+ production-tested AI prompts covering code review, security audit, debugging, testing, and architecture design. Compatible with Claude Code, ChatGPT, Cursor, Copilot, and any AI assistant.

## Changes

- Added one entry to the Resources list in README.md

## Checklist

- [x] Entry follows existing list format (name, link, em-dash description)
- [x] Description is concise and accurate
- [x] Link points to a valid public repository