### PR TITLE
Add claude-scaffold — npx CLI for deploying Claude Code configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Claude Code Open](https://github.com/kill136/claude-code-open) — Open-source AI coding platform with Web IDE, multi-agent system, 37+ tools, and MCP protocol support. Features browser-based IDE with Monaco editor, Blueprint multi-agent orchestration, and scheduled task daemon.
 - [Arctic](https://github.com/arctic-cli/interface): A terminal-first TUI that unifies multiple AI coding plans and APIs with built-in usage and quota visibility.
 - [models](https://github.com/arimxyer/models) — A TUI for browsing AI models, benchmarks from Artificial Analysis, and coding agents with GitHub integration. Built with Rust and Ratatui.
+- [claude-scaffold](https://github.com/pyramidheadshark/claude-scaffold) — npx scaffold CLI for Claude Code: deploys CLAUDE.md, hooks, and 18 domain skills (FastAPI, LangGraph, RAG, MLflow, etc.) to any repo. Auto-activates skills via hooks, supports cross-repo sync.
 
 ### Desktop
 


### PR DESCRIPTION
Adding claude-scaffold to the Command-line section.

claude-scaffold is an npx CLI that deploys a complete Claude Code configuration (CLAUDE.md, hooks, 18 domain skills, agents, CI templates) to any repository in one command. Skills auto-activate via UserPromptSubmit hooks based on project context (FastAPI routes → fastapi-patterns loads, LangGraph code → langgraph-patterns, etc.). Cross-repo sync via `npx claude-scaffold update --all`.

- GitHub: https://github.com/pyramidheadshark/claude-scaffold
- npm: https://npmjs.com/package/claude-scaffold