### PR TITLE
Add AI for Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Wren AI](https://getwren.ai/oss) — SQL AI Agent to get results and insights faster by asking questions without writing SQL, and it's open-source!
 - [TEXT2SQL.AI](https://www.text2sql.ai/) — AI-powered SQL query builder. Translate, explain and fix complex SQL queries using plain English.
 - [SQLAI.ai](https://www.sqlai.ai/) — AI generates, fixes, explains and optimizes SQL queries. Ability to add your own database schema and train AI to understand it.
+- [AI for Database](https://aifordatabase.com) — Connect to any database and query it in plain English. No SQL needed — get instant insights, build self-refreshing dashboards, and set up automated workflows triggered by database changes.
 
 #### Snippet & Utility Tools
 


### PR DESCRIPTION
## Description

Adding [AI for Database](https://aifordatabase.com) to the list of web-based AI developer tools, specifically in the database/SQL tools section alongside Wren AI, TEXT2SQL.AI, and SQLAI.ai.

**Tool details:**
- **Name:** AI for Database
- **URL:** https://aifordatabase.com
- **Description:** Connect to any database and interact with it in plain English. No SQL needed — get instant insights, build self-refreshing dashboards, and trigger automated workflows based on database changes.
- **Category:** Assistants > Web-based (database tools)

This tool fits naturally alongside the other database-oriented AI tools already listed in the Web-based Assistants section.