### PR TITLE
Add GAAI Framework to Agents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [Stoneforge](https://stoneforge.ai) — Open-source orchestration for AI coding agents. Run multiple agents in parallel with automatic dispatch, merge, and recovery.
 - [Trellis](https://github.com/mindfold-ai/Trellis) - All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
 - [brood-box](https://github.com/stacklok/brood-box) — Run coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation and egress control.
+- [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 
 ## PR agents
 


### PR DESCRIPTION
Adds [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) to the Agents section.

**What it is:** A drop-in `.gaai/` folder that adds governed delivery to AI coding tools. Agents remember decisions across sessions, only build what's in the backlog, and pass QA before shipping. Optional daemon delivers stories autonomously in parallel.

**Why Agents section:** GAAI orchestrates AI coding agents with governance — backlog authorization, persistent memory, QA gates, and context isolation between Discovery (reasoning) and Delivery (execution). Similar in scope to Agentic Sprint and Trellis but focused on SDLC governance.

**Multi-tool:** Claude Code (deep integration), Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.