### PR TITLE
Add burn0 to observability tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 
 ## Observability
 - [TraceRoot AI](https://traceroot.ai/) - An AI native observability tool that using AI agents to automatically fix your production bugs.
+- [burn0](https://github.com/burn0-dev/burn0) — Zero-config cost observability for Node.js. One import tracks per-request costs for 50+ APIs (OpenAI, Anthropic, Stripe, Supabase, etc.) right in your terminal. MIT licensed, privacy-first.
 
 ## OpenAI plugins
 


### PR DESCRIPTION
Added [burn0](https://github.com/burn0-dev/burn0) to the **Observability** section.

burn0 is an open-source, zero-config cost observability tool for Node.js that tracks per-request costs for 50+ APIs (OpenAI, Anthropic, Stripe, Supabase, etc.) right in the terminal. One import, sub-millisecond overhead, MIT licensed.

It fits the Observability category alongside TraceRoot AI as a developer tool for understanding API cost impact during development.