### PR TITLE
Add AIRIS MCP Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [rule-gen](https://github.com/nedcodes-ok/rule-gen) — CLI tool that generates AI coding rules from your actual codebase using Google Gemini. Feeds source files into Gemini's 1M token context window to produce project-specific rules for Cursor, Claude Code, Copilot, and Windsurf. Zero dependencies.
 - [Zenable](https://zenable.io/) — AI guardrails that learn your team's standards and ensure coding agents follow them, maximizing speed and quality.
 - [Gestalt](https://github.com/dwgoldie/gestalt) — Model-agnostic thinking protocol (AGENTS.md) that shapes how AI coding agents reason. Less filler, more substance, honest about limits. Works with Claude Code, Codex, Cursor, Copilot, Gemini CLI.
+- [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) — Docker-based MCP multiplexer exposing 60+ tools through 7 meta-tools. Reduces context tokens by 97%.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Summary

- Add [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) to Agent Infrastructure > Configuration & Context Management section
- Docker-based MCP multiplexer that exposes 60+ tools through 7 meta-tools, reducing context tokens by 97%

🤖 Generated with [Claude Code](https://claude.com/claude-code)