### PR TITLE
Add crit - human-in-the-loop review tool for AI agent workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [MiniMax Code Review](https://github.com/tarmojussila/minimax-code-review) - AI-powered GitHub Pull Request code review using MiniMax models.
 - [claude-pr-reviewer](https://github.com/indoor47/claude-pr-reviewer) - GitHub Action + CLI that uses Claude AI to automatically review pull requests, post inline comments, and report token costs. Supports strictness levels (lenient/balanced/strict). Zero dependencies, Python 3.8+.
 - [Revieko](https://synqra.tech/revieko/) — Architecture drift radar for PRs: structural risk scoring and drift hotspots.
+- [crit](https://crit.md) - Human-in-the-loop review for AI coding agents. Annotate plans, code, or any file with inline comments in a local browser UI; exports structured JSON your agent reads back. Share reviews via URL.
 - [CodeHawk](https://codehawk.crossgen-ai.com) — GitHub App that installs in seconds and reviews pull requests automatically, posting inline comments on bugs, security vulnerabilities, and logic errors.
 - [Grit](https://app.grit.io) — GitHub-integrated agent for automating maintenance tasks and other development work.
 - [PR Triage](https://pr-triage-web.vercel.app) — Open source PR evaluation tool that scores pull requests on six quality dimensions with diff evidence. BYOK, MIT licensed. [Source](https://github.com/Elifterminal/pr-triage-web)


### PR DESCRIPTION
Adding crit to PR & Code Review Bots.

crit is a local CLI that opens a browser UI for leaving inline comments on any file — plans, code, markdown, whatever your AI agent produced. Comments export as structured JSON (`.crit.json`) and feed back into Claude Code, Cursor, Aider, or any other agent as actionable feedback.

Different from everything else in this section: it's human-in-the-loop, not automated. The human reviews the agent's output; the agent reads the feedback. Single binary, works offline, shareable via crit.md.

- Site: https://crit.md
- CLI (Go): https://github.com/tomasz-tomczyk/crit
- Web (self-hostable): https://github.com/tomasz-tomczyk/crit-web