### PR TITLE
Add Nex

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [rule-gen](https://github.com/nedcodes-ok/rule-gen) — CLI tool that generates AI coding rules from your actual codebase using Google Gemini. Feeds source files into Gemini's 1M token context window to produce project-specific rules for Cursor, Claude Code, Copilot, and Windsurf. Zero dependencies.
 - [Zenable](https://zenable.io/) — AI guardrails that learn your team's standards and ensure coding agents follow them, maximizing speed and quality.
 - [Gestalt](https://github.com/dwgoldie/gestalt) — Model-agnostic thinking protocol (AGENTS.md) that shapes how AI coding agents reason. Less filler, more substance, honest about limits. Works with Claude Code, Codex, Cursor, Copilot, Gemini CLI.
+- [Nex](https://github.com/nex-crm/nex-as-a-skill) — Organizational context and memory for AI agents. Connects email, Slack, CRM, and 100+ tools into one knowledge graph with a 60-tool MCP server and persistent memory across agent sessions.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds [Nex](https://github.com/nex-crm/nex-as-a-skill) to the **Configuration & Context Management** section under Agent Infrastructure.

Nex is an open-source CLI and MCP server that provides organizational context and persistent memory for AI agents. It connects email, Slack, CRM, and 100+ tools into a single knowledge graph accessible via a 60-tool MCP server (`npx @nex-ai/nex`). Available on npm and Homebrew.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries