### PR TITLE
Add Kagan to IDE Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Plugins that add AI-powered completion, chat, and refactoring to existing code e
 - [Traycer](https://traycer.ai) - Plan-First Coding Assistant in VS Code.
 - [shadcn/studio MCP](https://shadcnstudio.com/mcp) — Integrate shadcn/studio MCP Server directly into your favorite IDE and craft stunning shadcn/ui Components, Blocks and Pages inspired by shadcn/studio.
 - [Sweep](https://sweep.dev/) — AI coding plugin for JetBrains IDEs with autocomplete, codebase indexing, and context-aware suggestions. Uses proprietary LLMs with zero data retention.
+- [Kagan](https://github.com/kagan-sh/kagan) — Open-source AI orchestration board with a VS Code extension for planning, running, and reviewing coding agent tasks.
 
 ---
 


### PR DESCRIPTION
## Description

[Kagan](https://github.com/kagan-sh/kagan) is an open-source (MIT) AI orchestration board with a VS Code extension for planning, running, and reviewing coding agent tasks.

The extension adds a task board, chat participant, live task output streaming, diff review, and merge workflows directly inside VS Code while connecting to the broader Kagan CLI / web / MCP workflow.

- **GitHub:** https://github.com/kagan-sh/kagan
- **Marketplace:** https://marketplace.visualstudio.com/items?itemName=kagan.kagan-vscode
- **Open VSX:** https://open-vsx.org/extension/kagan/kagan-vscode
- **Docs:** https://docs.kagan.sh/guides/vscode-extension/
- **License:** MIT

Added to **IDE Extensions** because the VS Code extension is now a first-class interface for orchestrating AI coding work.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries