### PR TITLE
Add IWE

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Butterfish](https://butterfi.sh) — CLI tool that embeds ChatGPT in your shell for easy access. Includes simple agentic capabilities.
 - [TmuxAI](https://tmuxai.dev/) - AI-powered, non-intrusive terminal assistant.
 - [intelli-shell](https://github.com/lasantosr/intelli-shell) - Manage command templates/snippets with dynamic completions and AI integration.
+- [IWE](https://github.com/iwe-org/iwe) — Markdown knowledge graph with CLI that gives AI agents structured access to your knowledge base — no vector database required.
 - [Hermes IDE](https://www.hermes-ide.com) — AI-powered shell wrapper for zsh, bash, and fish that adds ghost-text completions, autonomous task execution, full git management with worktrees, and multi-project sessions. Free and open source.
 
 ---


### PR DESCRIPTION
IWE is a Rust-based markdown knowledge management tool. Its CLI gives AI agents (Claude Code, Cursor, etc.) structured access to a markdown knowledge graph via commands like `iwe find` and `iwe retrieve --depth N`.

862+ GitHub stars, works with VS Code, Neovim, Zed, and Helix via LSP.

GitHub: https://github.com/iwe-org/iwe