### PR TITLE
Add WhereMyTokens to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [claude-lens](https://github.com/Astro-Han/claude-lens) — Lightweight Bash + jq statusline for Claude Code with rate limit pace tracking. Compares burn rate to time remaining in 5h/7d windows, showing whether usage is ahead or behind sustainable pace. Single file, zero dependencies beyond jq.
 - [ai-coding-tools-pricing](https://github.com/lunacompsia-oss/ai-coding-tools-pricing) — Open JSON dataset of pricing for 8 AI coding tools (Copilot, Cursor, Claude Code, Windsurf, etc.). 30+ tiers, TypeScript types, JSON Schema. CC-BY-4.0. Updated monthly.
 - [CodeCosts](https://codecosts.pages.dev) — Interactive cost calculator and comparison tool for AI coding tools. Uses the ai-coding-tools-pricing dataset to help developers pick the right plan.
+- [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) — Windows system tray app for monitoring Claude Code token usage in real time. Displays per-session token counts, costs, context window usage, and tool call breakdowns; fetches 5h/1w rate-limit data from the Anthropic API with optional statusLine bridge integration for live data without polling.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) to the **Usage Analytics & Cost Tracking** section.

WhereMyTokens is a Windows system tray app that monitors Claude Code token usage in real time — reads local JSONL session files for per-session token counts, costs, context window usage, and tool call breakdowns, and fetches 5h/1w rate-limit data from the Anthropic API. It also supports a `statusLine` bridge integration for live data without polling.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries