### PR TITLE
Add Uni-CLI to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [intelli-shell](https://github.com/lasantosr/intelli-shell) - Manage command templates/snippets with dynamic completions and AI integration.
 - [Hermes IDE](https://www.hermes-ide.com) — AI-powered shell wrapper for zsh, bash, and fish that adds ghost-text completions, autonomous task execution, full git management with worktrees, and multi-project sessions. Free and open source.
 - [resume-cli](https://github.com/inevolin/resume-cli) — CLI that aggregates recent sessions from Claude Code, Codex, and GitHub Copilot in one place. Pick a session and resume it in any of the three tools.
+- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) — Universal CLI for AI agents to control 167 websites, 28 desktop apps, and 8 Electron apps. Self-repairing 20-line YAML adapters, auto-JSON output when piped, ~80 tokens per call. Includes MCP server and browser daemon with Chrome login reuse.
 
 ---
 


### PR DESCRIPTION
Adds [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) to the CLI Utilities section.

Uni-CLI is a universal CLI for AI agents — 756 commands across 167 sites (web, desktop, Electron). Agents call `unicli <site> <command>` and get structured JSON. When adapters break, agents read the ~20 line YAML, fix it, and retry.

- ~80 tokens per invocation
- Built-in MCP server + browser daemon
- TypeScript, Apache-2.0
- `npm install -g @zenalexa/unicli`