### PR TITLE
Add sharable.link to Snippet & Utility Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Web utilities for quick code generation, language translation, and regex creatio
 - [AutoRegex](https://www.autoregex.xyz/) — AutoRegex uses OpenAI's GPT-3 to produce regular expressions from plain English.
 - [unpkg.ai](https://unpkg.ai/) — Open source AI-powered ESM module generation service. Generate JavaScript modules via URL for rapid prototyping.
 - [EnigmaEasel](https://enigmaeasel.com) — AI-powered engine for generating accessible color palettes and systems, OKLCH gradients, and font pairings with one-click Tailwind CSS and SCSS exports.
+- [sharable.link](https://sharable.link) — A free Claude skill that publishes HTML outputs to clean, shareable public URLs. One command turns dashboards, reports, and landing pages into links anyone can open.
 
 #### ChatGPT Plugins
 


### PR DESCRIPTION
## Summary

Adds [sharable.link](https://sharable.link) to the Snippet & Utility Tools section.

**sharable.link** is a free Claude skill that publishes HTML outputs to clean, shareable public URLs. Install the `/share` skill for Claude Code, build something (dashboards, reports, landing pages), say `/share` — get a clean URL anyone can open.

- **Website:** https://sharable.link
- **GitHub:** https://github.com/hembara/sharable-links-in-claude
- **Price:** Free forever