### PR TITLE
[codex] add OpenASE entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Platforms for running multiple AI coding agents in parallel with workspace isola
 - [Superset](https://superset.sh/) — Code editor for AI agents that orchestrates swarms of Claude Code, Codex, and other CLI-based agents in parallel. Uses isolated git worktrees with universal IDE integration.
 - [Sidecar](https://github.com/marcus/sidecar) — Terminal UI companion for CLI-based coding agents (Claude Code, Cursor, Gemini) with unified conversation history, git integration, task management, and workspace control.
 - [Vibe Kanban](https://vibekanban.com/) — AI-powered Kanban platform for orchestrating autonomous coding agents. Manage agent workflows with visual boards for task delegation and progress tracking.
+- [OpenASE](https://github.com/pacificstudio/openase) — Open-source ticket-driven platform for orchestrating Claude Code, Codex, and Gemini CLI agents across isolated workspaces and status-based workflows.
 - [Trellis](https://github.com/mindfold-ai/Trellis) — All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
 - [Upstream Agents](https://upstreamagents.com/) — Run AI coding agents in isolated sandboxes connected to your GitHub repositories. Supports Claude Code, odex and OpenCode.
 - [GolemBot](https://github.com/0xranx/golembot) — Unified framework wrapping Claude Code, Cursor, OpenCode, and Codex CLIs behind a single streaming API. Adds IM adapters (Slack, Telegram, Discord, Feishu), Skill system, fleet mode, and HTTP embedding.


### PR DESCRIPTION
## Description

Add OpenASE to the `Agent Infrastructure -> Multi-Agent Orchestration` section of the awesome list.

OpenASE is an AI-powered, developer-focused, open-source platform for orchestrating coding agents through ticket-driven workflows, isolated workspaces, and status-based execution.

## Main changes

- add a new `OpenASE` entry under `Multi-Agent Orchestration`
- describe the project in one sentence matching the list's existing style

## Validation

- reviewed the surrounding section for category fit and style consistency
- no automated checks run because this is a README-only change

## Risks and rollback

- low risk; this only adds one list entry
- rollback by removing the added README line if the categorization or wording needs adjustment
