### PR TITLE
Add sourcebook to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [Code to Flow](https://codetoflow.com) — Visualize, analyze, and understand code with interactive flowcharts.
 - [Gru.ai](https://www.gru.ai/) — An AI developer can help you solve technical problems and tackle daily coding tasks, such as building algorithms, debug issues, test solutions, answer programming questions, etc.
 - [sudocode](https://sudocode.ai/) — Context management system for AI coding agents that creates organizational structures to track context over long-horizon tasks.
+- [sourcebook](https://github.com/maroondlabs/sourcebook) — CLI and MCP server that generates AGENTS.md/CLAUDE.md from static analysis of codebase structure, git history, and convention detection. Surfaces hub files, co-change coupling, and blast radius. No LLM required.
 
 #### Database & SQL
 


### PR DESCRIPTION
## Description

Adds [sourcebook](https://github.com/maroondlabs/sourcebook) to the Codebase Intelligence section.

sourcebook is a CLI and MCP server that generates AGENTS.md/CLAUDE.md files from static analysis of codebase structure, git history, and convention detection. It surfaces hub files (most-depended-on modules), co-change coupling (files that always change together across directories), and blast radius. No LLM required — runs locally in seconds.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries