### PR TITLE
Add GrugBot420 to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [intelli-shell](https://github.com/lasantosr/intelli-shell) - Manage command templates/snippets with dynamic completions and AI integration.
 - [Hermes IDE](https://www.hermes-ide.com) — AI-powered shell wrapper for zsh, bash, and fish that adds ghost-text completions, autonomous task execution, full git management with worktrees, and multi-project sessions. Free and open source.
 - [resume-cli](https://github.com/inevolin/resume-cli) — CLI that aggregates recent sessions from Claude Code, Codex, and GitHub Copilot in one place. Pick a session and resume it in any of the three tools.
+- [GrugBot420](https://github.com/grug-group420/grugbot420) — Zero-dependency AI-powered CLI assistant built with Bun. Features server mode with HTTP API endpoints, pipeline-native shell integration, and a "Grug Brain Developer" philosophy emphasizing simplicity.
 
 ---
 


### PR DESCRIPTION
Adding [GrugBot420](https://github.com/grug-group420/grugbot420) — a zero-dependency AI-powered CLI assistant built with Bun. Features server mode with HTTP API endpoints, pipeline-native shell integration, and a "Grug Brain Developer" philosophy emphasizing simplicity over complexity. Open source.