### PR TITLE
Add SwarmClaw to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Platforms for running multiple AI coding agents in parallel with workspace isola
 - [Shep](https://github.com/shep-ai/cli) — Multi-session SDLC control center that orchestrates AI coding agents (Claude Code, Cursor CLI, Gemini) for autonomous feature development with configurable approval gates and a live web dashboard.
 - [Bernstein](https://github.com/chernistry/bernstein) — Deterministic multi-agent orchestrator that spawns parallel coding agents (Claude Code, Codex CLI, Gemini CLI) from a single goal, verifies with tests, and auto-commits. Zero LLM tokens on coordination.
 - [Kagan](https://github.com/kagan-sh/kagan) — Open-source AI orchestration board with a VS Code extension for planning, running, and reviewing coding agent tasks.
+- [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - Self-hosted AI runtime that orchestrates Claude Code, Codex, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, and Droid with heartbeats, schedules, delegation, runtime skills, and an org chart view. Ships as a desktop app (Electron) and CLI. MIT licensed, TypeScript.
 
 ### Sandboxing & Isolation
 


### PR DESCRIPTION
## Description

Adds [SwarmClaw](https://github.com/swarmclawai/swarmclaw) to the Multi-Agent Orchestration section.

SwarmClaw is a self-hosted AI runtime that orchestrates coding CLI agents (Claude Code, Codex, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, Droid) with heartbeats, schedules, delegation, and runtime skills. It includes an org chart view for managing agent teams and ships as a desktop app (Electron) and CLI. MIT licensed, TypeScript.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries