### PR TITLE
Add Northflank sandboxes to the sandboxing and isolation list

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Secure isolated environments for running AI coding agents with controlled access
 - [brood-box](https://github.com/stacklok/brood-box) — Run coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation and egress control.
 - [Open Agent](https://github.com/Th0rgal/openagent) — Self-hosted control plane for Claude Code with isolated container workspaces and real-time mission streaming.
 - [FlyDex](https://flydex.net) — Browser-first remote control plane for local Codex sessions with QR pairing, approvals, and machine continuity.
+- [Northflank Sandboxes](https://northflank.com/product/sandboxes) — Run untrusted code at scale with microVM isolation. Deploy in Northflank's cloud or your own VPC, with sub-second cold starts, horizontal autoscaling, and GPU support.
 
 ### Configuration & Context Management
 


### PR DESCRIPTION
Add [Northflank](https://northflank.com/) Sandboxes to the sandboxing and isolation list. Northflank Sandboxes provide isolated, ephemeral environments for running code securely, with support for containerized workloads.

<!--
IF YOU WANT YOUR CONTRIBUTION TO BE ACCEPTED:
This list is for developer tools exclusively.
The following are NOT valid submissions:
 ❌ General purpose AI agents/assistants
 ❌ General purpose AI frameworks
 ❌ Data analysis tools
See the checklist below for specific requirements.
-->

<!-- Please provide a brief description of the changes in this PR -->

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
