### PR TITLE
Add Helium MCP to IDE extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
 - [FlyonUI MCP](https://flyonui.com/mcp) — Integrate FlyonUI MCP - Tailwind AI Builder directly into your IDE and craft stunning Tailwind CSS Components, Blocks and Pages inspired by FlyonUI.
 - [Traycer](https://traycer.ai) - Plan-First Coding Assistant in VS Code.
 - [shadcn/studio MCP](https://shadcnstudio.com/mcp) - Integrate shadcn/studio MCP Server directly into your favorite IDE and craft stunning shadcn/ui Components, Blocks and Pages inspired by shadcn/studio.
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) — Real-time news with bias scoring, live market data, AI options pricing, and balanced news synthesis via MCP. ([Website](https://heliumtrades.com/mcp-page/))
 
 ### Command-line
 


### PR DESCRIPTION
Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) to the IDE extensions section alongside other MCP integrations. Helium provides real-time news with bias scoring, live market data, AI options pricing, and balanced news synthesis via MCP. Website: https://heliumtrades.com/mcp-page/