### PR TITLE
Add skill-optimizer to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [pi-steering-hooks](https://github.com/samfoy/pi-steering-hooks) — Deterministic before-tool-call guardrails for the pi coding agent. Enforces rules (no force push, conventional commits, etc.) via regex pattern matching on tool inputs — zero tokens, 100% reliable. Custom rules via JSON config with override escape hatch.
 - [Gestalt](https://github.com/dwgoldie/gestalt) — Model-agnostic thinking protocol (AGENTS.md) that shapes how AI coding agents reason. Less filler, more substance, honest about limits. Works with Claude Code, Codex, Cursor, Copilot, Gemini CLI.
 - [Agentify](https://github.com/koriyoshi2041/agentify) — CLI tool that transforms any OpenAPI spec into 9 agent interface formats (MCP server, AGENTS.md, CLAUDE.md, .cursorrules, Skills, llms.txt, GEMINI.md, A2A Card, CLI) with a single command. Tiered generation strategies for small to large APIs.
+- [skill-optimizer](https://github.com/fastxyz/skill-optimizer) — CLI that benchmarks SDK, CLI, and MCP guidance docs (SKILL.md) against multiple LLMs and runs an iterative optimizer to rewrite them until every configured model meets a score floor.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
skill-optimizer is a CLI developer tool that benchmarks your SDK, CLI, or MCP guidance docs (SKILL.md) against multiple LLMs, measuring whether models call the right tools with the right arguments. It then iteratively rewrites your docs until every configured model meets a score floor — making guidance doc quality measurable and improvable.

Fits under "Configuration & Context Management" alongside ctxlint, Caliber, and cursor-doctor as a tool that validates and improves AI context/guidance files.

Repo: https://github.com/fastxyz/skill-optimizer