### PR TITLE
Add AgentsMesh to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Platforms for running multiple AI coding agents in parallel with workspace isola
 - [Bernstein](https://github.com/chernistry/bernstein) — Deterministic multi-agent orchestrator that spawns parallel coding agents (Claude Code, Codex CLI, Gemini CLI) from a single goal, verifies with tests, and auto-commits. Zero LLM tokens on coordination.
 - [Kagan](https://github.com/kagan-sh/kagan) — Open-source AI orchestration board with a VS Code extension for planning, running, and reviewing coding agent tasks.
 - [pi-ralph](https://github.com/samfoy/pi-ralph) — Multi-agent orchestration loops for the pi coding agent. Runs autonomous implementation, review, and debugging cycles with configurable roles and loop chaining.
+- [AgentsMesh](https://agentsmesh.ai) — Self-hostable AI Agent Workforce Platform. Remote AI workstations (AgentPods) with PTY sandbox + git worktree isolation, multi-agent collaboration via channels and pod bindings, built-in Kanban with ticket-pod binding and MR/PR integration, per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode. Multi-Git (GitHub/GitLab/Gitee), multi-tenant (Org > Team > User), SSO/RBAC/audit, air-gapped, BYOK.
 
 ### Sandboxing & Isolation
 


### PR DESCRIPTION
Adding [AgentsMesh](https://agentsmesh.ai) to **Agent Infrastructure → Multi-Agent Orchestration**.

Fits the section definition exactly: "Platforms for running multiple AI coding agents in parallel with workspace isolation." AgentsMesh provisions remote AI workstations (AgentPods) with PTY sandbox + git worktree isolation per task, orchestrates multi-agent collaboration via channels and pod bindings, and manages work through a built-in Kanban with MR/PR integration.

**Distinguishing features vs existing entries**:
- Per-pod MCP server — Claude Code / Cursor can drive AgentsMesh through MCP tools
- Enterprise-grade multi-tenancy (Org > Team > User), SSO, RBAC, audit logs, air-gapped
- Multi-Git provider (GitHub / GitLab / Gitee)
- BYOK — no usage caps
- Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode, and custom terminal agents

1.5k+ stars, v0.28.0 (2026-04-15), BSL-1.1 (transitions to GPL-2.0-or-later on 2030-02-28).