### PR TITLE
Add Agent Cost Guardrails - budget limits for AI agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [ai-coding-tools-pricing](https://github.com/lunacompsia-oss/ai-coding-tools-pricing) — Open JSON dataset of pricing for 8 AI coding tools (Copilot, Cursor, Claude Code, Windsurf, etc.). 30+ tiers, TypeScript types, JSON Schema. CC-BY-4.0. Updated monthly.
 - [CodeCosts](https://codecosts.pages.dev) — Interactive cost calculator and comparison tool for AI coding tools. Uses the ai-coding-tools-pricing dataset to help developers pick the right plan.
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
+- [Agent Cost Guardrails](https://github.com/sapph1re/agent-cost-guardrails) — Budget limits and circuit breakers for AI agent frameworks (CrewAI, AutoGen, LangGraph). Framework-native hooks with hard token caps, cost alerts, and spend tracking — stop runaway agent costs before they hit your invoice.
 
 ---
 


### PR DESCRIPTION
## Summary

Adding [Agent Cost Guardrails](https://github.com/sapph1re/agent-cost-guardrails) to the **Usage Analytics & Cost Tracking** section.

**What it does:** Framework-native budget limits and circuit breakers for CrewAI, AutoGen, and LangGraph. Provides hard token caps, cost alerts, and spend tracking with hooks that integrate directly into the agent execution loop — not just post-hoc API billing monitoring.

**Why it fits this section:** The existing entries in Usage Analytics & Cost Tracking focus on monitoring AI coding tool costs (Claude Code, Cursor, Codex bills). Agent Cost Guardrails adds the missing piece: *enforcing* cost limits inside multi-agent applications before the bill arrives.

Links: [GitHub](https://github.com/sapph1re/agent-cost-guardrails) | [PyPI](https://pypi.org/project/agent-cost-guardrails/)