### PR TITLE
Add 4DA — codebase-aware developer intelligence (MCP server, 36 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Autonomous AI agents that work on existing codebases to fix bugs, refactor code,
 
 Tools for understanding, navigating, and getting answers about existing codebases:
 
+- [4DA / @4da/mcp-server](https://www.npmjs.com/package/@4da/mcp-server) — Desktop app + MCP server (36 tools) that gives AI coding assistants awareness of your tech stack, dependencies, and decisions. Scores content from HN, arXiv, Reddit, GitHub against your codebase. Live vulnerability scanning via OSV.dev. Privacy-first — everything stays local. `npx @4da/mcp-server`
 - [Sourcegraph Cody](https://about.sourcegraph.com/cody) — Assistant with chat, refactoring, and unit test generation. Extensions for VS Code and IntelliJ. Also available as a web app.
 - [Unblocked](https://getunblocked.com/) — Augment source code with relevant existing knowledge in GitHub, Slack, Jira, Confluence, and more. Get answers through chat and IDE file-level context. Available on web, macOS, Slack, VS Code, and JetBrains IDEs.
 - [Magnet](https://www.magnet.run/) — AI-native workspace for building software with repositories and issues as context.


### PR DESCRIPTION
## What

Adds [4DA / @4da/mcp-server](https://www.npmjs.com/package/@4da/mcp-server) to the **Codebase Intelligence** section.

## About

4DA is a desktop app + MCP server providing 36 tools for codebase-aware developer intelligence. It reads your project files (package.json, Cargo.toml, go.mod, etc.) and scores content from 10+ sources against what you actually build.

**Key capabilities:**
- **Codebase-aware scoring** — 5-axis relevance algorithm (semantic, interest, Git signals, dependency, learned behavior)
- **Live vulnerability scanning** — queries OSV.dev against your actual lockfile dependencies
- **Decision memory** — record and enforce architectural decisions across AI sessions
- **Knowledge gap detection** — finds blind spots in your dependency knowledge
- **Agent autonomy** — session briefs, context packets, delegation scoring

**Links:**
- **npm:** https://www.npmjs.com/package/@4da/mcp-server
- **Website:** https://4da.ai
- **Install:** `npx @4da/mcp-server --setup`
- **License:** MIT
- **Privacy-first:** Local SQLite, zero network calls, no telemetry
- **Works with:** Claude Code, Cursor, Windsurf, VS Code (Copilot), Claude Desktop