### PR TITLE
Add Docsmith — AI docs generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ Tools that generate commit messages and PR descriptions from diffs:
 Tools that auto-generate documentation, diagrams, and changelogs from source code:
 
 - [DiagramGPT](https://www.eraser.io/diagramgpt) — DiagramGPT is a free AI-based web app that converts a schema, infrastructure definition, code snippet or plain language description into diagrams. The tool can generate flow charts, entity relationship diagrams, cloud architecture diagrams and sequence diagrams.
+- [Docsmith](https://docsmithai.com) — AI documentation site generator. Powered by Claude, generates full docs sites from GitHub repos.
 - [DocuPilot](https://docupilot-alpha.vercel.app) — GitHub App that auto-updates README, CHANGELOG, and API docs on every push using AI. [[GitHub](https://github.com/AkrMcmr/docupilot)]
 - [DocuWriter.ai](https://www.docuwriter.ai/) — AI-powered web app to generate automated Code & API documentation from your source code files.
 - [README-AI](https://github.com/eli64s/readme-ai) — Automated README.md file generator, powered by large language model APIs.


### PR DESCRIPTION
Adding Docsmith to the Documentation Generation subsection. Powered by Claude Sonnet 4.6 via the Anthropic API. Generates not just docstrings but full navigable docs sites from a repo URL.