### PR TITLE
Add unslop CLI to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [resume-cli](https://github.com/inevolin/resume-cli) — CLI that aggregates recent sessions from Claude Code, Codex, and GitHub Copilot in one place. Pick a session and resume it in any of the three tools.
 - [codesight](https://github.com/Houseofmvps/codesight) — CLI token optimizer and AI context generator. Scans codebases to extract routes, schema, components, and dependencies for Claude Code, Cursor, Copilot, Codex, and Windsurf. 9x–13x token reduction, built-in MCP server, zero runtime dependencies. `npx codesight`
 - [CLIRank](https://clirank.dev) — API directory scoring 387 APIs on agent-friendliness across 11 signals. Available as an MCP server (`clirank-mcp-server`) and REST API.
+- [unslop](https://github.com/MohamedAbdallah-14/unslop) — CLI and MCP server that removes AI writing patterns from text output. Detects and rewrites tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Lint-only audit mode for passive inspection. Five intensity levels. Useful for cleaning commit messages, PR descriptions, and documentation.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [unslop](https://github.com/MohamedAbdallah-14/unslop) to the **CLI Utilities** section.

**What it does:** CLI and MCP server that removes AI writing patterns from text output. Targets tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Lint-only audit mode lets you inspect what would change without modifying the file. Five intensity levels.

**Practical use in the dev workflow:** cleans AI-generated commit messages, PR descriptions, documentation drafts, and README files before they go out. Integrates as an MCP tool so any MCP-compatible AI client can call it inline.

**Checklist:**
- [x] Open source, MIT licensed
- [x] CLI tool, no GUI required
- [x] Works standalone or as MCP server with Claude Code, Cursor, Windsurf
