### PR TITLE
feat: add KubeStellar Console kc-agent to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [Gestalt](https://github.com/dwgoldie/gestalt) — Model-agnostic thinking protocol (AGENTS.md) that shapes how AI coding agents reason. Less filler, more substance, honest about limits. Works with Claude Code, Codex, Cursor, Copilot, Gemini CLI.
 - [Agentify](https://github.com/koriyoshi2041/agentify) — CLI tool that transforms any OpenAPI spec into 9 agent interface formats (MCP server, AGENTS.md, CLAUDE.md, .cursorrules, Skills, llms.txt, GEMINI.md, A2A Card, CLI) with a single command. Tiered generation strategies for small to large APIs.
 - [skill-optimizer](https://github.com/fastxyz/skill-optimizer) — CLI that benchmarks SDK, CLI, and MCP guidance docs (SKILL.md) against multiple LLMs and runs an iterative optimizer to rewrite them until every configured model meets a score floor.
+- [KubeStellar Console kc-agent](https://github.com/kubestellar/console) — MCP server that bridges AI coding agents (Claude Code, Copilot, Codex) to multi-cluster Kubernetes APIs. Enables natural language queries across clusters, workload placement, policy enforcement, and real-time observability. CNCF Sandbox project.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## What is this?

[KubeStellar Console's kc-agent](https://github.com/kubestellar/console) is an MCP server that bridges AI coding agents to multi-cluster Kubernetes APIs.

## Why it belongs in Configuration & Context Management

`kc-agent` provides Kubernetes cluster context to AI coding agents via the MCP protocol:
- Bridges Claude Code, Copilot, Codex, and other AI agents to real Kubernetes clusters.
- Provides natural language access to pods, deployments, services, and CNCF project resources across multiple clusters.
- Enables AI-assisted workload placement, policy enforcement, and incident response.
- CNCF Sandbox project.

Similar to how Context7 provides library documentation context or ContextMCP provides semantic search context, kc-agent provides Kubernetes infrastructure context to AI coding agents.