### PR TITLE
feat: add Grasp — code architecture visualiser with 116 MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [Code to Flow](https://codetoflow.com) — Visualize, analyze, and understand code with interactive flowcharts.
 - [Gru.ai](https://www.gru.ai/) — An AI developer can help you solve technical problems and tackle daily coding tasks, such as building algorithms, debug issues, test solutions, answer programming questions, etc.
 - [sudocode](https://sudocode.ai/) — Context management system for AI coding agents that creates organizational structures to track context over long-horizon tasks.
+- [Grasp](https://github.com/ashfordeOU/grasp) — Code architecture visualiser: paste any GitHub/GitLab URL → interactive dependency graph (9 layouts, 16 colour modes), A–F health score, security scanner (SARIF 2.1 export), blast radius, churn heatmap, ORM query map, and AI chat (15 providers). 116 MCP tools with Kuzu graph DB + SQLite brain. Zero data collection, everything runs locally. `npm install -g grasp-mcp-server`
 
 #### Database & SQL
 


### PR DESCRIPTION
Adding [Grasp](https://github.com/ashfordeOU/grasp) to the Codebase Intelligence section.

Grasp lets you paste any GitHub/GitLab URL and instantly get an interactive dependency graph (9 layouts, 16 colour modes), A–F health score, security scanner, blast radius, churn heatmap, ORM query map, and AI chat with 15 providers. 116 MCP tools, Kuzu graph DB + SQLite brain. Zero data collection — everything runs locally.

`npm install -g grasp-mcp-server`