### PR TITLE
Add Puppyone to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [Gestalt](https://github.com/dwgoldie/gestalt) — Model-agnostic thinking protocol (AGENTS.md) that shapes how AI coding agents reason. Less filler, more substance, honest about limits. Works with Claude Code, Codex, Cursor, Copilot, Gemini CLI.
 - [Agentify](https://github.com/koriyoshi2041/agentify) — CLI tool that transforms any OpenAPI spec into 9 agent interface formats (MCP server, AGENTS.md, CLAUDE.md, .cursorrules, Skills, llms.txt, GEMINI.md, A2A Card, CLI) with a single command. Tiered generation strategies for small to large APIs.
 - [skill-optimizer](https://github.com/fastxyz/skill-optimizer) — CLI that benchmarks SDK, CLI, and MCP guidance docs (SKILL.md) against multiple LLMs and runs an iterative optimizer to rewrite them until every configured model meets a score floor.
+- [Puppyone](https://github.com/puppyone-ai/puppyone) — Self-hostable file system for AI coding agents. Auto-versioned writes, per-agent ACLs (File Level Security), audit logs, and 15+ OAuth connectors (Notion/GitHub/Drive/Linear) syncing external sources as agent-readable files. Native MCP / REST / CLI / sandbox bindings to one persistent Context Space. Apache 2.0, Docker self-host.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## What this adds

Adds [Puppyone](https://github.com/puppyone-ai/puppyone) to **Agent Infrastructure → Configuration & Context Management**.

## What it is

Puppyone is a self-hostable file system designed for AI coding agents. It complements existing entries in this section (ContextMCP, Beacon, AgentsKB, faf-cli) by providing the **storage substrate** for persistent agent context — not a config sync tool, but the underlying versioned file layer that those tools can read/write to.

Key properties for AI coding workflows:

- **Auto-versioned writes** — every agent edit is snapshotted automatically, no manual `git commit`. One-click rollback when an agent goes off the rails.
- **Per-agent ACLs (File Level Security)** — different Cursor / Claude Code / Cline sessions get different views of the same Context Space. Useful for multi-agent setups where you don't want one agent leaking context into another.
- **15+ OAuth connectors** — Notion, GitHub, Drive, Linear, etc. sync external sources as agent-readable files. Drop a Notion page in, your IDE agent reads it as a file via MCP.
- **Multi-channel exposure** — same files reachable via MCP / REST / CLI / sandbox.

## Why it fits this section

The section already includes context-management tools (Context7, ContextMCP, faf-cli, AgentsKB). Puppyone is the storage layer those operate on top of: persistent, versioned, per-agent-scoped files that any MCP-aware agent can read.

- Repo: https://github.com/puppyone-ai/puppyone
- Site: https://www.puppyone.ai
- License: Apache 2.0
- Tech: Python (FastAPI) + Next.js + Supabase + Docker

Made with [Cursor](https://cursor.com)