### PR TITLE
Add remove-audio.com - free browser-based audio remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,3 +446,6 @@ Curated lists, comparison guides, and configuration templates for AI coding tool
 - [Havoptic](https://havoptic.com/) — Free, open-source timeline tracking releases from AI coding tools. Auto-updated daily. [Source](https://github.com/scotthavird/havoptic.com)
 - [AI Dev Toolkit](https://github.com/dohko04/awesome-ai-prompts-for-devs) — 198 production-ready AI engineering resources: prompt frameworks, multi-agent configs, MCP setups, RAG pipelines, and automation scripts for Claude Code, Cursor, GPT-5, Copilot, and more. Free samples included.
 - [AI Coding Guide (中文)](https://github.com/jnMetaCode/ai-coding-guide) — Chinese best practices for 8 AI coding tools (Claude Code, Cursor, Copilot, Windsurf, Gemini CLI, Kiro, Aider, Trae) with copy-paste config templates and multi-tool collaboration workflows.
+
+
+* [Remove audio from video](https://remove-audio.com) - Free, browser-based audio remover. Local processing via WebAssembly. No signup, no watermarks. Batch up to 20 clips.


### PR DESCRIPTION
This adds https://remove-audio.com to the list.

It is a free, browser-based tool that strips audio from video files using FFmpeg.wasm and WebAssembly. All processing is local - no files are uploaded to any server. No signup, no watermarks, batch support for up to 20 clips.

Fits this list because: it is a free web tool for video processing.