### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 Tools for monitoring token usage and API costs across AI providers:
 
 - [Tokscale](https://github.com/junhoyeo/tokscale) — CLI tool for tracking token usage from AI coding agents (OpenCode, Claude Code, OpenClaw, Codex, Gemini CLI, Cursor IDE, AmpCode, Factory Droid) with a global leaderboard and 2D/3D contribution graphs.
+- [agenttrace](https://github.com/luoyuctl/agenttrace) — Local-first TUI for auditing AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, and related logs. Shows cost, tokens, tool failures, latency, anomalies, health, diffs, and CI gates.
 - [BurnRate](https://getburnrate.io) - Local-first AI coding cost analytics. Tracks Claude Code, Cursor, Codex, Copilot, Windsurf, Cline, and Aider. Cost breakdowns, 23 optimization rules, rate limit monitoring, provider comparison, and PDF reports.
 - [Code Insights](https://github.com/melagiri/code-insights) — Local-first CLI and dashboard for analyzing AI coding sessions from Claude Code, Cursor, Codex CLI, Copilot CLI, and VS Code Copilot Chat. SQLite-backed with terminal analytics, browser dashboard, and LLM-powered insights.
 - [onWatch](https://github.com/onllm-dev/onwatch) — Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI Codex, GitHub Copilot, Synthetic, Z.ai, MiniMax, Antigravity). Background daemon with Material Design 3 web dashboard, ~15MB binary, <50MB RAM, zero telemetry.


### PR DESCRIPTION
## Description

Adds agenttrace to Usage Analytics & Cost Tracking. It is a local-first TUI for auditing AI coding agent sessions across cost, tokens, tool failures, latency, anomalies, health, diffs, and CI gates.

Validation:
- git diff --check passed
- awesome-lint was run; it reports existing repository-wide issues unrelated to this one-line addition

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries