### PR TITLE
Add Uni-CLI to Terminal > CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [resume-cli](https://github.com/inevolin/resume-cli) — CLI that aggregates recent sessions from Claude Code, Codex, and GitHub Copilot in one place. Pick a session and resume it in any of the three tools.
 - [codesight](https://github.com/Houseofmvps/codesight) — CLI token optimizer and AI context generator. Scans codebases to extract routes, schema, components, and dependencies for Claude Code, Cursor, Copilot, Codex, and Windsurf. 9x–13x token reduction, built-in MCP server, zero runtime dependencies. `npx codesight`
 - [CLIRank](https://clirank.dev) — API directory scoring 387 APIs on agent-friendliness across 11 signals. Available as an MCP server (`clirank-mcp-server`) and REST API.
+- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) — Self-repairing CLI catalog exposing 237+ websites, desktop apps, and external CLIs as deterministic commands for AI agents. 920 declarative YAML adapters; structured error envelopes (`adapter_path`, `step`, `suggestion`) let agents fix failing adapters and retry. Optional MCP server (stdio + Streamable HTTP). Median ~80 tokens per call.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) to **Terminal → CLI Utilities**. Uni-CLI is a self-repairing TypeScript CLI that exposes 237+ websites, desktop apps, and external CLIs as deterministic commands for AI agents (Claude Code, Codex, Cursor, etc.). Sits naturally next to existing entries like `CLIRank`, `codesight`, and `cmd-ai`.

920 declarative YAML adapters + 216 TS adapters surface 3,319 commands. Structured error envelopes (`adapter_path`, `step`, `suggestion`) let the calling agent edit a failing adapter and retry. Optional MCP server (stdio + Streamable HTTP). Median ~80 tokens per call.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries