### PR TITLE
Add OpenClaw Monitor to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 Tools for monitoring token usage and API costs across AI providers:
 
 - [Tokscale](https://github.com/junhoyeo/tokscale) — CLI tool for tracking token usage from AI coding agents (OpenCode, Claude Code, OpenClaw, Codex, Gemini CLI, Cursor IDE, AmpCode, Factory Droid) with a global leaderboard and 2D/3D contribution graphs.
+- [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) — Local-first monitoring dashboard for OpenClaw AI agents. Tracks Cron task scheduling, 7-day token usage trends, and multi-model cost comparison. Self-hosted, privacy-focused.
 - [BurnRate](https://getburnrate.io) - Local-first AI coding cost analytics. Tracks Claude Code, Cursor, Codex, Copilot, Windsurf, Cline, and Aider. Cost breakdowns, 23 optimization rules, rate limit monitoring, provider comparison, and PDF reports.
 - [Code Insights](https://github.com/melagiri/code-insights) — Local-first CLI and dashboard for analyzing AI coding sessions from Claude Code, Cursor, Codex CLI, Copilot CLI, and VS Code Copilot Chat. SQLite-backed with terminal analytics, browser dashboard, and LLM-powered insights.
 - [onWatch](https://github.com/onllm-dev/onwatch) — Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI Codex, GitHub Copilot, Synthetic, Z.ai, MiniMax, Antigravity). Background daemon with Material Design 3 web dashboard, ~15MB binary, <50MB RAM, zero telemetry.


### PR DESCRIPTION
## OpenClaw Monitor

Local-first monitoring dashboard for OpenClaw AI agents. Tracks Cron task scheduling, 7-day token usage trends, and multi-model cost comparison.

- **GitHub**: https://github.com/flik2002/openclaw-monitor

Fits naturally in the Usage Analytics & Cost Tracking section alongside tools like Tokscale and BurnRate. Self-hosted, privacy-focused.