### PR TITLE
Add VULK (vulk.dev) to App Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Platforms that scaffold and deploy full-stack applications from natural language
 - [Make Real](https://makereal.tldraw.com/) — Online canvas that can be used to generate HTML/JavaScript apps.
 - [Glowbom](https://glowbom.com/) — Generate apps with AI and export to multiple platforms.
 - [ScrollHub](https://hub.scroll.pub/) — Generate and publish websites using the Scroll programming language.
+- [VULK](https://vulk.dev) — AI app builder that generates full-stack React + PostgreSQL apps, Flutter mobile, Three.js games and Shopify themes from natural language. Live preview in Firecracker microVMs, BYOM with 16+ models, EU-hosted with full source code export.
 - [Taskade Genesis](https://taskade.com/genesis) — AI-powered platform for building custom AI agents, workflows, and apps using natural language. Multi-model support (GPT-4o, Claude, Gemini), open-source MCP server.
 - [Berrry](https://berrry.app) — Twitter app generator that transforms social media posts into functional web applications. Turn tweets and Reddit content into complete apps with unique subdomains.
 - [Blank Space](https://www.blankspace.build/) — Open-source AI app builder for creating web applications using natural language. Self-hostable alternative to v0, Lovable, and Bolt.


### PR DESCRIPTION
Adds [VULK](https://vulk.dev) — an AI-powered full-stack app builder — to the **Web-Based Tools › App Builders** section.

**Why it fits the list:**
- Generates production-ready full-stack apps (React + PostgreSQL backend with auto-generated CRUD/REST/JWT auth) from a single natural-language prompt
- Multi-platform: web, Flutter mobile (iOS + Android), Three.js / WebGL games, Shopify themes (Liquid + Hydrogen + App Bridge), PHP/Laravel
- Live preview runs in **Firecracker microVMs** (same isolation tech as AWS Lambda), <2s cold-boot
- **BYOM** — connects user-supplied API keys for OpenAI / Anthropic / Google / Mistral / Groq / DeepSeek / OpenRouter with zero markup
- 16+ AI models routed automatically by complexity (Gemini 3.1 Pro default, Claude Opus 4.7, GPT-5.5, Grok, etc.)
- EU-hosted infrastructure (PostgreSQL on AWS Frankfurt, app on Hetzner Falkenstein)
- Full source code export — ZIP + GitHub push, no proprietary runtime, no lock-in
- Public API + OpenAPI 3.1 spec at https://vulk.dev/openapi.json so AI agents can drive it programmatically
- MCP server published as \`vulk-mcp-server\` on npm for Claude Desktop / Cursor / Windsurf integration

Differentiates from Bolt.new and Lovable on:
- Mobile (real Flutter builds, not React Native wrapper)
- 3D / WebGL games
- Shopify Liquid theme generation
- BYOM (bring your own LLM key)
- EU residency / GDPR compliance

Built solo by João Castro (Portugal). Live at https://vulk.dev — happy to answer questions.