### PR TITLE
Add VULK (vulk.dev) to App Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Platforms that scaffold and deploy full-stack applications from natural language
 - [Make Real](https://makereal.tldraw.com/) — Online canvas that can be used to generate HTML/JavaScript apps.
 - [Glowbom](https://glowbom.com/) — Generate apps with AI and export to multiple platforms.
 - [ScrollHub](https://hub.scroll.pub/) — Generate and publish websites using the Scroll programming language.
+- [VULK](https://vulk.dev) — AI app builder that generates full-stack React + PostgreSQL apps, Flutter mobile, Three.js games and Shopify themes from natural language. Live preview in Firecracker microVMs, BYOM with 16+ models, EU-hosted with full source code export.
 - [Taskade Genesis](https://taskade.com/genesis) — AI-powered platform for building custom AI agents, workflows, and apps using natural language. Multi-model support (GPT-4o, Claude, Gemini), open-source MCP server.
 - [Berrry](https://berrry.app) — Twitter app generator that transforms social media posts into functional web applications. Turn tweets and Reddit content into complete apps with unique subdomains.
 - [Blank Space](https://www.blankspace.build/) — Open-source AI app builder for creating web applications using natural language. Self-hostable alternative to v0, Lovable, and Bolt.

--- a/README.md
+++ b/README.md
@@ -455,3 +455,4 @@ Curated lists, comparison guides, and configuration templates for AI coding tool
 - [Havoptic](https://havoptic.com/) — Free, open-source timeline tracking releases from AI coding tools. Auto-updated daily. [Source](https://github.com/scotthavird/havoptic.com)
 - [AI Dev Toolkit](https://github.com/dohko04/awesome-ai-prompts-for-devs) — 198 production-ready AI engineering resources: prompt frameworks, multi-agent configs, MCP setups, RAG pipelines, and automation scripts for Claude Code, Cursor, GPT-5, Copilot, and more. Free samples included.
 - [AI Coding Guide (中文)](https://github.com/jnMetaCode/ai-coding-guide) — Chinese best practices for 8 AI coding tools (Claude Code, Cursor, Copilot, Windsurf, Gemini CLI, Kiro, Aider, Trae) with copy-paste config templates and multi-tool collaboration workflows.
+


### PR DESCRIPTION
## Description

Adds [VULK](https://vulk.dev) to the **Web-Based Tools › App Builders** section.

VULK is an AI-powered developer tool that turns natural-language prompts into deployable full-stack applications. It is positioned alongside existing entries in the same section (Bolt.new, Lovable, Co.dev, Capacity, etc.) and differentiates on:

- **Real Flutter mobile builds** (server-side .apk / .ipa with code-signing) — not a React Native wrapper.
- **Three.js / WebGL games** — Three.js + React Three Fiber + Drei + Rapier physics generation.
- **Shopify Liquid theme generation** — full Online Store 2.0 themes from a description.
- **Firecracker microVM live preview** — same isolation tech as AWS Lambda; <2s cold-boot.
- **BYOM** — connect your own LLM API key (OpenAI / Anthropic / Google / Mistral / Groq / OpenRouter / Ollama) with zero markup.
- **EU-hosted** — Postgres on AWS Frankfurt, app on Hetzner Falkenstein. Full code export (ZIP + GitHub push).
- **Public REST API** with OpenAPI 3.1 spec at https://vulk.dev/openapi.json so AI agents (Claude Desktop, Cursor, Windsurf) can call VULK as a tool.
- **MCP server** published as \`vulk-mcp-server\` on npm.

Live at https://vulk.dev. Built solo by João Castro (Portugal).

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries