### PR TITLE
feat: Add OpenClaw Monitor — Real-time AI Agent Monitoring Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 Tools for monitoring token usage and API costs across AI providers:
 
 - [Tokscale](https://github.com/junhoyeo/tokscale) — CLI tool for tracking token usage from AI coding agents (OpenCode, Claude Code, OpenClaw, Codex, Gemini CLI, Cursor IDE, AmpCode, Factory Droid) with a global leaderboard and 2D/3D contribution graphs.
+- [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) — Real-time AI agent monitoring dashboard for OpenClaw. Tracks Gateway status, session metrics, and token usage with live charts.
 - [BurnRate](https://getburnrate.io) - Local-first AI coding cost analytics. Tracks Claude Code, Cursor, Codex, Copilot, Windsurf, Cline, and Aider. Cost breakdowns, 23 optimization rules, rate limit monitoring, provider comparison, and PDF reports.
 - [Code Insights](https://github.com/melagiri/code-insights) — Local-first CLI and dashboard for analyzing AI coding sessions from Claude Code, Cursor, Codex CLI, Copilot CLI, and VS Code Copilot Chat. SQLite-backed with terminal analytics, browser dashboard, and LLM-powered insights.
 - [onWatch](https://github.com/onllm-dev/onwatch) — Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI Codex, GitHub Copilot, Synthetic, Z.ai, MiniMax, Antigravity). Background daemon with Material Design 3 web dashboard, ~15MB binary, <50MB RAM, zero telemetry.


### PR DESCRIPTION
## Description

Add [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) to the Usage Analytics & Cost Tracking section.

OpenClaw Monitor is a real-time AI agent monitoring dashboard that tracks:
- Gateway connection and session status
- Token usage (prompt/completion) with visual charts
- Multi-agent monitoring with 7-day trend history
- WebSocket-based live updates

This is a developer-focused tool for tracking AI agent activity and costs, fitting the list's focus on Usage Analytics & Cost Tracking tools.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
