### PR TITLE
feat: add llm-prices — CLI for comparing LLM API pricing across 93 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [CodeCosts](https://codecosts.pages.dev) — Interactive cost calculator and comparison tool for AI coding tools. Uses the ai-coding-tools-pricing dataset to help developers pick the right plan.
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
+- [llm-prices](https://github.com/benbencodes/llm-prices) — Zero-dependency CLI and Python library for looking up and comparing LLM API pricing across **93 models and 15 providers** (OpenAI, Anthropic, Google, Mistral, xAI, Amazon Bedrock, and more). Supports `list`, `calc`, `compare`, `top`, and `budget` commands. No API key required.
 
 ---
 


### PR DESCRIPTION
## What

Adds [llm-prices](https://github.com/benbencodes/llm-prices) to the **Usage Analytics & Cost Tracking** section.

## Description

`llm-prices` is a zero-dependency Python CLI and library for looking up and comparing LLM API pricing across **93 models and 15 providers**.

Unlike session/token trackers in this section, `llm-prices` is a *static pricing reference* — it answers "which model is cheapest for my workload?" before you write a line of code. Complementary to dynamic cost trackers like BurnRate or aicost.

```bash
$ pip install llm-prices

# Find the 5 cheapest models for a 5k input / 1k output workload
$ llm-prices top 5 --in 5000 --out 1000

# Compare specific models side-by-side
$ llm-prices compare gpt-4o claude-sonnet-4-6 gemini-2.5-pro grok-4.3 --in 5000 --out 1000

# Calculate exact cost for a call
$ llm-prices calc gpt-4o --in 10000 --out 2000

# Export all 93 models as CSV
$ llm-prices list --csv > prices.csv
```

**License**: MIT  
**Language**: Python (zero dependencies, stdlib only)  
**Providers covered**: OpenAI, Anthropic, Google, Mistral, Groq, Cohere, DeepSeek, xAI, Together AI, Fireworks AI, Perplexity, Cerebras, SambaNova, Amazon Bedrock, AI21 Labs