### PR TITLE
Add mirrord to Sandboxing & Isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Secure isolated environments for running AI coding agents with controlled access
 - [brood-box](https://github.com/stacklok/brood-box) — Run coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation and egress control.
 - [Open Agent](https://github.com/Th0rgal/openagent) — Self-hosted control plane for Claude Code with isolated container workspaces and real-time mission streaming.
 - [FlyDex](https://flydex.net) — Browser-first remote control plane for local Codex sessions with QR pairing, approvals, and machine continuity.
+- [mirrord](https://github.com/metalbear-co/mirrord) — Per-agent isolation inside a shared Kubernetes cluster: traffic filters, DB branches, and Kafka queue splits via the mirrord Operator. Six [Claude Code skills](https://github.com/metalbear-co/skills) cover quickstart, config, operator setup, CI, DB branching, and Kafka splitting; install via `/plugin marketplace add metalbear-co/skills`.
 
 ### Configuration & Context Management
 


### PR DESCRIPTION
## Description

Adds mirrord to the Sandboxing & Isolation section.

mirrord provides per-agent isolation inside a *shared* remote Kubernetes cluster, complementing the existing entries (VibeBox, brood-box, Open Agent, FlyDex) which isolate AI agents on the local machine. Where those tools sandbox the agent's *machine*, mirrord sandboxes the agent's *cluster session*: each agent gets its own slice of traffic, database, and Kafka topic on a real shared staging cluster.

The companion [metalbear-co/skills](https://github.com/metalbear-co/skills) repo ships six Claude Code skills covering install, config, operator setup, CI, DB branching, and Kafka splitting.

- mirrord: 5,059 stars, 57 contributors, MIT-licensed
- Skills repo published as a Claude Code plugin and via `npx skills add`
- Used by AI-agent customers at monday.com (350+ engineers on shared cluster), Daylight Security, and others.

## Checklist

- [x] The entry is a tool that uses AI (interpretation: tool used in the AI coding agent workflow, matching the existing Sandboxing & Isolation entries which are also infrastructure rather than AI themselves)
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries