### PR TITLE
Add prpack (CLI) and prpack-action (Action)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [resume-cli](https://github.com/inevolin/resume-cli) — CLI that aggregates recent sessions from Claude Code, Codex, and GitHub Copilot in one place. Pick a session and resume it in any of the three tools.
 - [codesight](https://github.com/Houseofmvps/codesight) — CLI token optimizer and AI context generator. Scans codebases to extract routes, schema, components, and dependencies for Claude Code, Cursor, Copilot, Codex, and Windsurf. 9x–13x token reduction, built-in MCP server, zero runtime dependencies. `npx codesight`
 - [CLIRank](https://clirank.dev) — API directory scoring 387 APIs on agent-friendliness across 11 signals. Available as an MCP server (`clirank-mcp-server`) and REST API.
+- [prpack](https://github.com/Lucas2944/prpack) — Zero-dep CLI that packs a pull request (diff + commits + full post-change file contents) into one markdown file optimized for LLM code review. Drop the file into Claude / Cursor / your model. MIT.
 
 ---
 
@@ -309,6 +310,7 @@ Integrations that automatically review pull requests and suggest code fixes:
 - [CodeHawk](https://codehawk.crossgen-ai.com) — GitHub App that installs in seconds and reviews pull requests automatically, posting inline comments on bugs, security vulnerabilities, and logic errors.
 - [Grit](https://app.grit.io) — GitHub-integrated agent for automating maintenance tasks and other development work.
 - [PR Triage](https://pr-triage-web.vercel.app) — Open source PR evaluation tool that scores pull requests on six quality dimensions with diff evidence. BYOK, MIT licensed. [Source](https://github.com/Elifterminal/pr-triage-web)
+- [prpack-action](https://github.com/Lucas2944/prpack-action) — GitHub Action that runs prpack on every PR, uploads the packed markdown as an artifact, and posts a summary comment. MIT.
 
 ### CI/CD & Testing Automation
 


### PR DESCRIPTION
Two related entries:

**CLI Utilities** — [prpack](https://github.com/Lucas2944/prpack)
Zero-dependency Node CLI (MIT). Packs a pull request — diff plus the full post-change content of every touched file — into one markdown file. Drop into Claude / Cursor / your model and ask for review.

```sh
npx github:Lucas2944/prpack --out ctx.md
```

**PR & Code Review Bots** — [prpack-action](https://github.com/Lucas2944/prpack-action)
GitHub Action that runs prpack on every PR, uploads the packed markdown as a workflow artifact, and posts a summary comment with file count + token estimate.

```yaml
- uses: Lucas2944/prpack-action@v1
```

Both follow the existing list format. The writeup behind the technique: [Your LLM code reviewer is reading half the file](https://scottthurman.hashnode.dev/your-llm-code-reviewer-is-reading-half-the-file).