### PR TITLE
Add TokenWise to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [CodeCosts](https://codecosts.pages.dev) — Interactive cost calculator and comparison tool for AI coding tools. Uses the ai-coding-tools-pricing dataset to help developers pick the right plan.
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
+- [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [TokenWise](https://github.com/CodeShuX/tokenwise) under \`### Usage Analytics & Cost Tracking\` — a Claude Code skill that auto-routes subtasks across Haiku/Sonnet/Opus, logs every routed task with verified \$ saved, and includes an A/B test mode that scores cheaper-tier outputs before you trust the routing.

Differs from existing entries in the section: \`Tokscale\`, \`BurnRate\`, \`Code Insights\`, \`onWatch\`, \`aicost\`, \`CostGoat\` etc. all **observe** cost. TokenWise **routes** while observing — so it actively reduces cost instead of just reporting it.

## Checklist

- [x] The entry is a tool that uses AI (it's an AI routing skill that delegates between Claude models)
- [x] The entry is a developer-focused tool (Claude Code skill, CLI install)
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

License: MIT