### PR TITLE
feat: add llm-prices to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [CodeCosts](https://codecosts.pages.dev) — Interactive cost calculator and comparison tool for AI coding tools. Uses the ai-coding-tools-pricing dataset to help developers pick the right plan.
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
+- [llm-prices](https://github.com/benbencodes/llm-prices) — Zero-dependency Python CLI and MCP server for comparing LLM API pricing across 152 models and 22 providers (OpenAI, Anthropic, Gemini, Mistral, xAI, DeepSeek, Groq, and more). No API key required — pricing data is baked in.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [llm-prices](https://github.com/benbencodes/llm-prices) to the **Usage Analytics & Cost Tracking** section.

`llm-prices` is a zero-dependency Python CLI and MCP server for comparing LLM API pricing across **152 models and 22 providers** (OpenAI, Anthropic, Google, Mistral, xAI, DeepSeek, Groq, and more). No API key required — pricing data is baked in.

Key features:
- `llm-prices list` — tabular comparison across all providers
- `llm-prices top 10` — find the 10 cheapest models for your context window
- `llm-prices compare gpt-4o claude-sonnet-4-6` — side-by-side cost comparison
- `llm-prices calc gpt-4o 10000 5000` — calculate cost for specific token counts
- MCP server for cost queries from AI agents

Fits directly in the Usage Analytics & Cost Tracking section alongside tools that help developers understand and compare AI API costs.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
