### PR TITLE
Add Memory & Knowledge section with dakera-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
   - [Sandboxing & Isolation](#sandboxing--isolation)
   - [Configuration & Context Management](#configuration--context-management)
   - [Usage Analytics & Cost Tracking](#usage-analytics--cost-tracking)
+  - [Memory & Knowledge](#memory--knowledge)
 - [Specialized Tools](#specialized-tools)
   - [Git & Commit Helpers](#git--commit-helpers)
   - [Documentation Generation](#documentation-generation)
@@ -406,6 +407,12 @@ Tools for monitoring token usage and API costs across AI providers:
 - [CodeCosts](https://codecosts.pages.dev) — Interactive cost calculator and comparison tool for AI coding tools. Uses the ai-coding-tools-pricing dataset to help developers pick the right plan.
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
+
+### Memory & Knowledge
+
+Tools for giving AI coding agents persistent memory and structured knowledge access:
+
+- [dakera-cli](https://github.com/Dakera-AI/dakera-mcp) — Rust CLI for managing a self-hosted agent memory server during development — inspect memories, manage namespaces, query vectors, and configure decay from the command line.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Tools for monitoring token usage and API costs across AI providers:
 
 Tools for giving AI coding agents persistent memory and structured knowledge access:
 
-- [dakera-cli](https://github.com/Dakera-AI/dakera-mcp) — Rust CLI for managing a self-hosted agent memory server during development — inspect memories, manage namespaces, query vectors, and configure decay from the command line.
+- [dakera-cli](https://github.com/Dakera-AI/dakera-cli) — Rust CLI for managing a self-hosted agent memory server during development — inspect memories, manage namespaces, query vectors, and configure decay from the command line.
 
 ---
 


### PR DESCRIPTION
## Description

Adds a new **Memory & Knowledge** subsection under **Agent Infrastructure**, with `dakera-cli` as the first entry. There is currently no memory/knowledge management category in the list. As agents become more capable, persistent memory infrastructure has become a core part of the AI dev toolchain. `dakera-cli` is an open-source Rust CLI for developers who self-host the Dakera memory server — inspect memories, manage namespaces, run vector queries, and tune decay settings from the command line.

**Suggested entry:**
```
- [dakera-cli](https://github.com/Dakera-AI/dakera-cli) — Rust CLI for managing a self-hosted agent memory server during development — inspect memories, manage namespaces, query vectors, and configure decay from the command line.
```

**Suggested placement:** Agent Infrastructure → Memory & Knowledge (new subsection)

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries