### PR TITLE
Add OpenQuack to Desktop Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Native desktop apps for AI-powered coding, terminal enhancement, and agent orche
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app that runs multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) in parallel with automatic git worktree isolation, a unified GUI, and remote monitoring.
 - [PATAPIM](https://patapim.ai) — Terminal IDE for AI coding agents with a 9-terminal grid, AI state detection, built-in Whisper voice dictation, LAN remote access, and embedded MCP browser. Built with Electron.
 - [IM.codes](https://github.com/im4codes/imcodes) — Mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents, built for away-from-desk continuation with terminal access, file browsing, git views, localhost preview, notifications, and multi-agent workflows.
+- [OpenQuack](https://github.com/larryxiao/openquack) - Privacy-first local voice dictation menu bar app for macOS. Pairs with Claude Code, Cursor, Codex, and Aider to dictate long contextual prompts; transcribes via WhisperKit on Apple Silicon, pastes at the cursor, ~8 MB, MIT.
 
 ---
 


### PR DESCRIPTION
## Description

Adds OpenQuack to the **Desktop Applications** section.

OpenQuack is a privacy-first, MIT-licensed local voice dictation menu-bar app for macOS. It pairs naturally with AI coding tools (Claude Code, Cursor, Codex, Aider) — press a hotkey, dictate the long contextual prompt you'd otherwise type, and OpenQuack pastes the transcript at your cursor. Transcription runs locally on Apple Silicon via WhisperKit. ~8 MB binary, no cloud, no telemetry, no account.

Inserted at the end of the Desktop Applications section. Hyphen separator to match the Warp / Parallel Code / Nimbalyst entries.

Repo: https://github.com/larryxiao/openquack
Integration docs: https://github.com/larryxiao/openquack/blob/main/docs/integrations/claude-code.md

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries