### PR TITLE
Add Dakera: self-hosted MCP agent memory server to Config & Context section

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Secure isolated environments for running AI coding agents with controlled access
 
 Tools that manage and sync AI agent configurations, rules, and context across editors:
 
+- [Dakera](https://github.com/Dakera-AI/dakera) — Self-hosted agent memory server providing persistent cross-session memory for AI coding agents. Hybrid BM25 + HNSW vector retrieval, decay-weighted recall, multi-agent namespacing, and MCP integration. Works with Claude Code, Cursor, Windsurf, and any MCP client. SDKs for Python, TypeScript, Go, and Rust.
 - [Context7](https://context7.com/) — Documentation platform that provides up-to-date, version-specific documentation and code examples for any library directly into Cursor, Claude Code, Windsurf, and other AI coding tools.
 - [cursor-doctor](https://github.com/nedcodes-ok/cursor-doctor) — Health scanner and diagnostic tool for Cursor AI IDE configuration (.cursor/rules/ files). Scans for broken YAML frontmatter, rule conflicts, redundancies, missing alwaysApply, token budget issues, and stack coverage gaps. Available as CLI (`npx cursor-doctor scan`) and VS Code extension.
 - [ctxlint](https://github.com/YawLabs/ctxlint) — Open-source linter for AI context files (CLAUDE.md, .cursorrules, copilot-instructions.md) that catches stale paths, wrong commands, and token waste by validating against the real codebase.


### PR DESCRIPTION
## Description

Adds [Dakera](https://github.com/Dakera-AI/dakera) to the **Configuration & Context Management** section.

Dakera is a self-hosted agent memory server that gives AI coding agents persistent cross-session memory:
- Hybrid BM25 + HNSW vector retrieval for semantic recall
- Decay-weighted memory (importance scores fade over time)
- Multi-agent namespacing for isolated memory per agent
- MCP-native integration — works with Claude Code, Cursor, Windsurf, and any MCP client
- SDKs for Python, TypeScript, Go, and Rust

Unlike configuration-file-based context tools, Dakera persists agent memories (decisions, preferences, discoveries) across sessions and projects, enabling stateful agents.
