### PR TITLE
Add swarm-orchestrator to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ Platforms for running multiple AI coding agents in parallel with workspace isola
 - [pi-ralph](https://github.com/samfoy/pi-ralph) — Multi-agent orchestration loops for the pi coding agent. Runs autonomous implementation, review, and debugging cycles with configurable roles and loop chaining.
 - [great_cto](https://github.com/avelikiy/great_cto) — Claude Code plugin with 7 specialized agents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor) running a full SDLC pipeline with 12-angle code review, 10 project archetypes, 13 compliance frameworks, and two-gate approval flow (architecture + deploy).
 - [AgentsMesh](https://agentsmesh.ai) — Self-hostable AI Agent Workforce Platform. Remote AI workstations (AgentPods) with PTY sandbox + git worktree isolation, multi-agent collaboration via channels and pod bindings, built-in Kanban with ticket-pod binding and MR/PR integration, per-pod MCP server. Supports Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode. Multi-Git (GitHub/GitLab/Gitee), multi-tenant (Org > Team > User), SSO/RBAC/audit, air-gapped, BYOK.
+- [swarm-orchestrator](https://github.com/moonrunnerkc/swarm-orchestrator) — Contract-first multi-agent orchestrator that races persona candidates per typed obligation, verifies before commit, and logs every action in an append-only hash-chained ledger. Deterministic offline default with optional Claude, Codex, Copilot, and local LLM (Ollama, llama.cpp, vLLM) providers. Ships with a GitHub Action.
 
 ### Sandboxing & Isolation
 


### PR DESCRIPTION
## Description

Adds [swarm-orchestrator](https://github.com/moonrunnerkc/swarm-orchestrator) to the **Multi-Agent Orchestration** section.

swarm-orchestrator is a contract-first multi-agent orchestrator for AI coding agents. It races persona candidates per typed obligation in a single cached inference session, verifies before commit, and logs every action in an append-only hash-chained ledger. The default provider is fully deterministic and runs offline with no model installs or API keys; optional providers include Anthropic Claude, OpenAI Codex, GitHub Copilot, and local LLM backends (Ollama, llama.cpp, vLLM, OpenAI-compatible). Ships with a GitHub Action.

This fits the Multi-Agent Orchestration section alongside tools like Bernstein, Stoneforge, SwarmClaw, and AgentsMesh.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries