### PR TITLE
Add AgentTier to Sandboxing & Isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Secure isolated environments for running AI coding agents with controlled access
 - [brood-box](https://github.com/stacklok/brood-box) — Run coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation and egress control.
 - [Open Agent](https://github.com/Th0rgal/openagent) — Self-hosted control plane for Claude Code with isolated container workspaces and real-time mission streaming.
 - [FlyDex](https://flydex.net) — Browser-first remote control plane for local Codex sessions with QR pairing, approvals, and machine continuity.
+- [AgentTier](https://github.com/agenttier/agenttier) — Open-source, Kubernetes-native sandbox runtime for AI coding agents (Claude Code, LangGraph, OpenHands). Each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation; runs in interactive `mode: code` (browser terminal) or `mode: agent` (REST `/configure` + SSE-streaming `/invoke`). Apache-2.0.
 
 ### Configuration & Context Management
 


### PR DESCRIPTION
## Description

This PR adds [AgentTier](https://github.com/agenttier/agenttier) under `Agent Infrastructure → Sandboxing & Isolation`.

AgentTier is an open-source, Kubernetes-native sandbox runtime for AI coding agents. It sits next to the existing entries in this section: VibeBox (per-project micro-VM on macOS), brood-box (microVM with snapshot isolation), and Open Agent (container workspaces). AgentTier targets the Kubernetes deployment model — each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor for kernel-level isolation, and a per-session ServiceAccount.

It supports both interactive and headless flows: `mode: code` (browser terminal over WebSocket → SPDY exec) and `mode: agent` (REST `/configure` to install agent code, then SSE-streaming `/invoke` to run it). Reference templates ship for Claude Code + AWS Bedrock and a model-free LangGraph agent.

License: Apache-2.0. Project URL: https://github.com/agenttier/agenttier.

## Checklist

- [x] The entry is a tool that uses AI — hosts AI coding agents (Claude Code, LangGraph, OpenHands) the same way VibeBox/brood-box/Open Agent do.
- [x] The entry is a developer-focused tool — provides isolated sandboxes for human developers and AI agents to write, run, and persist code.
- [x] The description is unambiguous and clear.
- [x] The description matches the style of other entries — single bullet, sentence case, factual, similar length to peers in the same section.

The diff is a single-line addition appended after the existing FlyDex entry.
