### PR TITLE
Add APort to agent infrastructure tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [Agentify](https://github.com/koriyoshi2041/agentify) — CLI tool that transforms any OpenAPI spec into 9 agent interface formats (MCP server, AGENTS.md, CLAUDE.md, .cursorrules, Skills, llms.txt, GEMINI.md, A2A Card, CLI) with a single command. Tiered generation strategies for small to large APIs.
 - [skill-optimizer](https://github.com/fastxyz/skill-optimizer) — CLI that benchmarks SDK, CLI, and MCP guidance docs (SKILL.md) against multiple LLMs and runs an iterative optimizer to rewrite them until every configured model meets a score floor.
 - [KubeStellar Console kc-agent](https://github.com/kubestellar/console) — MCP server that bridges AI coding agents (Claude Code, Copilot, Codex) to multi-cluster Kubernetes APIs. Enables natural language queries across clusters, workload placement, policy enforcement, and real-time observability. CNCF Sandbox project.
+- [APort](https://aport.io) — Agent identity and policy enforcement for AI-agent tool calls, with [guardrail integration examples](https://github.com/aporthq/aport-integrations) for pre-action authorization.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds APort to the Agent Infrastructure section as a developer-focused tool for AI-agent identity, policy enforcement, and pre-action authorization around tool calls. The entry links both the product website and the guardrail integration examples repository.

Validation:
- Verified https://aport.io returns HTTP 200
- Verified https://github.com/aporthq/aport-integrations returns HTTP 200
- Ran `git diff --check`

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries