### PR TITLE
Add Blueprint to IDE Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Plugins that add AI-powered completion, chat, and refactoring to existing code e
 - [Sweep](https://sweep.dev/) — AI coding plugin for JetBrains IDEs with autocomplete, codebase indexing, and context-aware suggestions. Uses proprietary LLMs with zero data retention.
 - [Antigravity Link](https://github.com/cafeTechne/antigravity-link-extension) — VS Code extension that bridges mobile devices to Google's Antigravity IDE. Mirror active AI chat sessions on your phone, send messages, upload files, stop AI generation, and automate workflows via a local HTTP API or 9 MCP tools. Listed in the official MCP Registry.
 - [Shadcn Space MCP](https://shadcnspace.com/mcp) — Connect Cursor, Claude Code, Antigravity, VS Code, and other AI tools to the Shadcn Space component registry.
-- [Blueprint](https://marketplace.visualstudio.com/items?itemName=Imbue.imbue-blueprint) — Open-source planning copilot for coding agents. Asks multiple-choice questions about your codebase, then generates a markdown plan any coding agent can execute. Extensions for VS Code, Cursor, and Windsurf.
+- [Blueprint](https://marketplace.visualstudio.com/items?itemName=Imbue.imbue-blueprint) — Open-source planning copilot for coding agents. Asks multiple-choice questions about your task, then generates a markdown plan any coding agent can execute. Extensions for VS Code, Cursor, and Windsurf.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Plugins that add AI-powered completion, chat, and refactoring to existing code e
 - [Sweep](https://sweep.dev/) — AI coding plugin for JetBrains IDEs with autocomplete, codebase indexing, and context-aware suggestions. Uses proprietary LLMs with zero data retention.
 - [Antigravity Link](https://github.com/cafeTechne/antigravity-link-extension) — VS Code extension that bridges mobile devices to Google's Antigravity IDE. Mirror active AI chat sessions on your phone, send messages, upload files, stop AI generation, and automate workflows via a local HTTP API or 9 MCP tools. Listed in the official MCP Registry.
 - [Shadcn Space MCP](https://shadcnspace.com/mcp) — Connect Cursor, Claude Code, Antigravity, VS Code, and other AI tools to the Shadcn Space component registry.
+- [Blueprint](https://marketplace.visualstudio.com/items?itemName=Imbue.imbue-blueprint) — Open-source planning copilot for coding agents. Asks multiple-choice questions about your codebase, then generates a markdown plan any coding agent can execute. Extensions for VS Code, Cursor, and Windsurf.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [Blueprint](https://marketplace.visualstudio.com/items?itemName=Imbue.imbue-blueprint) to **Development Environments > IDE Extensions**.

Blueprint is an open-source planning copilot for coding agents by [Imbue](https://imbue.com). It asks multiple-choice questions about your task, then generates a markdown plan any coding agent can execute. Extensions for VS Code, Cursor, and Windsurf.

- VS Code Marketplace: https://marketplace.visualstudio.com/items?itemName=Imbue.imbue-blueprint
- GitHub (for Cursor and Windsurf): https://github.com/imbue-ai/blueprint-vscode

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries