### PR TITLE
Add Agent FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Memex](https://memex.tech/) — Build anything in any stack, with just natural language, on your desktop.
 - [Poirot](https://github.com/LeonardoCardoso/Poirot) — A macOS app for browsing Claude Code sessions, exploring diffs, and re-running commands. Reads local transcripts, runs offline, open source.
 - [Anima](https://github.com/btangonan/anima) — Native macOS companion for Claude Code with per-project ASCII familiars, nim token economy, and cross-session watcher. Tauri v2 + Rust, 4MB.
+- [Agent FM](https://github.com/agentfm-ai/agent-fm) — Local, open-source macOS app that turns Claude Code and Codex sessions into narrated stations, surfacing progress, blockers, decisions, errors, and attention requests.
 - [CCHub](https://github.com/Moresl/cchub) — Claude Code ecosystem management platform with visual GUI for MCP server management, skill management, multi-config switching, custom slash commands, and JSON config editing. Built with Tauri v2.
 - [Mantra](https://mantra.gonewx.com) — Desktop session time machine for AI coding tools. Captures and restores full conversation state for Claude Code, Cursor, and Windsurf — like quicksave for your AI sessions. Free for macOS.
 - [Dorothy](https://github.com/Charlie85270/Dorothy) — Open-source desktop app to orchestrate multiple AI coding agents (Claude Code, Codex, Gemini) simultaneously with automations, Kanban management, and remote control.


### PR DESCRIPTION
## Description

Adds Agent FM to Desktop & Mobile Applications. It is a local, open-source macOS companion for Claude Code and Codex sessions that turns useful session activity into live narration.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
