### PR TITLE
Add GreatCTO to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Platforms for running multiple AI coding agents in parallel with workspace isola
 - [Stoneforge](https://stoneforge.ai) — Open-source orchestration for AI coding agents. Run multiple agents in parallel with automatic dispatch, merge, and recovery.
 - [Shep](https://github.com/shep-ai/cli) — Multi-session SDLC control center that orchestrates AI coding agents (Claude Code, Cursor CLI, Gemini) for autonomous feature development with configurable approval gates and a live web dashboard.
 - [Bernstein](https://github.com/chernistry/bernstein) — Deterministic multi-agent orchestrator that spawns parallel coding agents (Claude Code, Codex CLI, Gemini CLI) from a single goal, verifies with tests, and auto-commits. Zero LLM tokens on coordination.
+- [GreatCTO](https://github.com/avelikiy/great_cto) — Multi-agent SDLC orchestrator running above Claude Code, Cursor, Codex, Aider, and Continue. 34 specialist agents (architect → reviewers → devops), 25 archetype overlays (fintech, healthcare, agent-product, voice-AI), and 10 compliance packs (PCI/HIPAA/EU AI Act/TCPA) auto-wired by repo detection. Two human gates per feature.
 - [Kagan](https://github.com/kagan-sh/kagan) — Open-source AI orchestration board with a VS Code extension for planning, running, and reviewing coding agent tasks.
 - [pi-ralph](https://github.com/samfoy/pi-ralph) — Multi-agent orchestration loops for the pi coding agent. Runs autonomous implementation, review, and debugging cycles with configurable roles and loop chaining.
 


### PR DESCRIPTION
## Description

Adds GreatCTO to the Multi-Agent Orchestration section. It's a multi-agent SDLC orchestrator that runs above Claude Code, Cursor, Codex, Aider, and Continue — fits the section's "platforms for running multiple AI coding agents in parallel" framing exactly.

Entry placed alphabetically between GolemBot and Kagan.

Notable specifics that make it distinct from existing entries:
- **Archetype-driven routing.** Detects fintech / healthcare / voice-AI / etc. from your repo manifests and overlays the right compliance gates automatically (PCI, HIPAA, TCPA, EU AI Act).
- **Two human gates per feature** (\`gate:plan\`, \`gate:ship\`). Everything between runs unattended.
- **Live state-machine diagram** with every node clickable to the agent's source: https://greatcto.systems/architecture
- **Public proof of one real run** (voice-pack rollout, full timeline, costs, artifacts): https://greatcto.systems/proof
- **Public benchmark methodology** for the cross-project memory claim (47 paired P0 incidents): https://github.com/avelikiy/great_cto/blob/main/docs/benchmarks/MTTR.md

Repo: https://github.com/avelikiy/great_cto
Install: \`npx great-cto init\`
License: MIT
~12.5k npm installs/month, weekly releases.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries (single-line, em-dash, technical specifics)