### PR TITLE
Add Reflex — local-first code search engine for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [Kasava](https://kasava.dev) - Parses codebases and reads every commit so progress reports cite real changes and feature plans are made with real architecture context.
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
+- [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adds [Reflex](https://github.com/reflex-search/reflex) (`rfx`) to the **Codebase Intelligence** section.

Reflex is a local-first, full-text code search engine designed specifically for AI coding agents and automation workflows. It replaces Sourcegraph Code Search for local use, returning every occurrence of a pattern — not just symbol definitions — with file paths, line numbers, and surrounding context.

Key AI-agent capabilities:
- Structured JSON output for agent consumption
- Optional MCP server mode (`rfx serve`) so agents query the codebase as a tool
- Sub-100ms search across 10k+ files via trigram indexing
- Regex support, language filtering, and symbol-aware filtering (`--symbols`)

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries