### PR TITLE
Add Vibe Island to Desktop & Mobile Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [IM.codes](https://github.com/im4codes/imcodes) — Mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents, built for away-from-desk continuation with terminal access, file browsing, git views, localhost preview, notifications, and multi-agent workflows.
 - [OpenQuack](https://github.com/larryxiao/openquack) - Privacy-first local voice dictation menu bar app for macOS. Pairs with Claude Code, Cursor, Codex, and Aider to dictate long contextual prompts; transcribes via WhisperKit on Apple Silicon, pastes at the cursor, ~8 MB, MIT.
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
+- [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [Vibe Island](https://vibeisland.app) to the **Desktop & Mobile Applications** section.

Vibe Island is a native macOS app that turns the MacBook notch into a control panel for 18 AI coding CLIs (Claude Code, Codex, Gemini CLI, Cursor Agent, Droid, OpenCode, Copilot and others). Permission prompts surface in the notch with inline allow/deny, ExitPlanMode previews render with markdown, AskUserQuestion options are clickable, and clicking a notification jumps back to the exact terminal pane or IDE split that triggered the prompt. Usage limits are pulled from each provider's native source (statusline cache for Claude, JSONL + app-server for Codex, OAuth quota for Cursor) and displayed in one unified bar.

Inserted at the end of the Desktop & Mobile Applications section. Em-dash separator to match Warp / Pieces / Anima / Agent FM / CCHub / Mantra / Dorothy / Nimbalyst entries. Positioned alongside the multi-agent management apps (CCHub, Dorothy, Nimbalyst) since the primary differentiator is unified control across many CLIs rather than monitoring one.

Built in Swift 6 with strict concurrency (actors + Sendable), AppKit + SwiftUI. Universal binary, macOS 13+. Sparkle EdDSA-signed auto-updates.

Site: https://vibeisland.app

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
