### PR TITLE
Add AI Models Catalog to Resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Curated lists, comparison guides, and configuration templates for AI coding tool
 
 - [aiforcode.io](https://aiforcode.io) — Expert-curated directory of 42+ AI coding tools with transparent 100-point scoring, head-to-head comparisons, and an interactive tool recommendation quiz. Verified monthly.
 - [Awesome Code Docs](https://github.com/johnxie/awesome-code-docs) — Curated deep-dive tutorials for open-source AI and developer tooling projects.
+- [AI Models Catalog](https://github.com/i-need-token/ai-models) — Structured open-source database of 4,587+ AI models across 95 providers with pricing, context windows, modalities, and capabilities. Interactive catalog with model comparison, price calculator, and model picker for choosing the right LLM.
 - [AI Coding Compare](https://aicodingcompare.com) — Compare 50+ AI coding assistants with features, pricing, and performance benchmarks.
 - [ClaudeDown](https://claudedown.com) - Real-time Claude AI complaint tracker and outage detector using Twitter/X sentiment data.
 - [Havoptic](https://havoptic.com/) — Free, open-source timeline tracking releases from AI coding tools. Auto-updated daily.


### PR DESCRIPTION
## Description

Adds the AI Models Catalog to the Resources section — a structured, open-source database of 4,587+ AI models across 95 providers with pricing, context windows, modalities, and capabilities.

## Why This Is Useful for AI Dev Tool Users

- **Model comparison**: Compare pricing, context windows, and capabilities across 95 providers
- **Price calculator**: Calculate monthly costs based on your token usage
- **Model picker**: Get recommendations based on your use case (coding, agents, etc.)
- **Interactive catalog**: https://i-need-token.github.io/ai-models/
- **First-party data**: All data sourced from provider APIs
- **npm package + GitHub Action**: Programmatic access for dev tools

## Links

- GitHub: https://github.com/i-need-token/ai-models
- Interactive Catalog: https://i-need-token.github.io/ai-models/
- LLM Pricing Comparison: https://i-need-token.github.io/ai-models/llm-pricing.html
- Cheapest AI Models: https://i-need-token.github.io/ai-models/cheapest-ai-models.html

## Checklist

- [x] The entry follows the existing format of the list
- [x] The entry is relevant to AI developer tools
- [x] The description is concise and follows the style of other entries