### PR TITLE
Add Primio

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Platforms that scaffold and deploy full-stack applications from natural language
 - [Blank Space](https://www.blankspace.build/) — Open-source AI app builder for creating web applications using natural language. Self-hostable alternative to v0, Lovable, and Bolt.
 - [Fastshot](https://fastshot.ai/) — AI driven no-code platform for building and deploying mobile apps.
 - [ai-vertical-saas-gen](https://github.com/kurtnebiev-elvis4/ai-vertical-saas-gen) — CLI that generates complete vertical SaaS apps (Next.js 14 + Supabase) with industry-specific data models for 20+ niches. Zero dependencies, offline, outputs 20 deployable files in one command.
+- [Primio](https://primio.dev) — Builds full-stack Flutter apps for mobile and web from a conversational prompt, with live preview, an in-browser emulator, and one-click publishing to the app stores.
 
 ### UI Generators
 


### PR DESCRIPTION
Adds Primio to the App Builders section.

[Primio](https://primio.dev) builds full-stack Flutter apps for mobile and web from a conversational prompt, with live preview, an in-browser emulator, and one-click publishing to the app stores.