### PR TITLE
Add Selvedge to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [Selvedge](https://github.com/masondelan/selvedge) — Local MCP server that captures the reasoning behind every AI-written code change. Query with `selvedge blame` for entity-level history with the original prompt context. Open source (MIT), Python 3.10+, all data local.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adds Selvedge to the **Codebase Intelligence** section under Web-Based Tools.

Selvedge is an AI-codebase observability CLI + MCP server. AI coding agents call it as they work to log structured change events — entity, diff, and reasoning — to a local SQLite database. It solves a problem specific to AI-written code: `git blame` points at the model, generated commit messages have lost the prompt context, and the original session is gone. Selvedge captures the agent's intent live, from the same context window that produced the change.

**Closest peer in the list:** `sourcebook` — both are static-analysis CLI+MCP for codebase context. Selvedge complements it on the change-history axis (event log + reasoning) where sourcebook covers structure and coupling.

- Open source (MIT), Python 3.10+
- v0.3.6 latest, 340+ tests passing
- All data stays local (SQLite under `.selvedge/`)
- Works with Claude Code, Cursor, Copilot — `selvedge setup` detects and configures all three
- Hardened across Python 3.10–3.13 and SQLite 3.37–3.45

Six MCP tools exposed: log_change, diff, blame, history, changeset, search.

Happy to revise category, description, or alphabetization.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries