### PR TITLE
Add Selvedge to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [Selvedge](https://github.com/masondelan/selvedge) — Local MCP server that captures the reasoning behind every AI-written code change. Query with `selvedge blame` for entity-level history with the original prompt context, or `prior_attempts` so the agent reads prior reasoning before it edits. Open source (MIT), Python 3.10+, all data local.
 
 ### Database & SQL
 


### PR DESCRIPTION
Adding Selvedge to the awesome-ai-devtools list.

**Category fit:** Selvedge is an AI-codebase observability tool — it captures *why* AI agents change code, in the moment they make the change. Solves a problem that emerges specifically as a codebase takes on more agent-written code: `git blame` points at the model, generated commit messages have lost the prompt context, and the session is gone.

**Closest peer in the list:** `sourcebook` — both are static-analysis CLI+MCP for codebase context. Selvedge complements it on the change-history axis (event log + reasoning) where sourcebook covers structure and coupling.

- Open source (MIT), Python 3.10+
- v0.3.7 latest, pytest/ruff/mypy all green
- All data stays local (SQLite under `.selvedge/`)
- Works with Claude Code, Cursor, Copilot — `selvedge setup` detects and configures all three
- Hardened across Python 3.10–3.13 and SQLite 3.37–3.45

Seven tools exposed: `log_change`, `diff`, `blame`, `history`, `changeset`, `search`, `prior_attempts` — with `prior_attempts` (new in v0.3.7), the agent reads prior reasoning before it edits.

Happy to revise category, description, or alphabetization.
