### PR TITLE
Add Clave to Desktop & Mobile Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [OpenQuack](https://github.com/larryxiao/openquack) - Privacy-first local voice dictation menu bar app for macOS. Pairs with Claude Code, Cursor, Codex, and Aider to dictate long contextual prompts; transcribes via WhisperKit on Apple Silicon, pastes at the cursor, ~8 MB, MIT.
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
+- [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
 
 ---
 


### PR DESCRIPTION
Adds [Clave](https://github.com/codika-io/clave) to **Desktop & Mobile Applications**.

Clave is a native macOS app for managing multiple Claude Code sessions in parallel — split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first. Sits alongside existing entries like Parallel Code, Dorothy, and Nimbalyst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)