### PR TITLE
Add Prompter - multi-model Ollama comparison CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [Prompter](https://github.com/whonixnetworks/prompter) — CLI tool for comparing the same prompt across multiple Ollama models side-by-side. Useful for evaluating which local LLM handles a given coding, reasoning, or system-ops prompt best. Single Python file, curses TUI.
 
 ---
 


### PR DESCRIPTION
## Description

Add [Prompter](https://github.com/whonixnetworks/prompter) — a CLI tool for comparing the same prompt across multiple Ollama models side-by-side. Useful for evaluating which local LLM handles a given coding, reasoning, or system-ops prompt best. Single Python file, curses TUI.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries