### PR TITLE
Add ccg-router to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [ccg-router](https://github.com/XZXY-AI/ccg-router) — Local-first Go daemon that fronts both Claude Code (Anthropic-compatible) and Codex CLI (OpenAI-compatible) on one port and records every request to a local SQLite ledger. Built-in usage dashboard with per-upstream and per-model cost/error breakdowns, Prometheus `/metrics`, a `ledger summary` CLI, and an optional AES-256-GCM-encrypted ledger at rest. No hosted control plane; provider keys never leave your machine. Apache-2.0.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **ccg-router** to the **Usage Analytics & Cost Tracking** section. It is an open-source (Apache-2.0) local Go daemon that fronts both Claude Code (Anthropic-compatible) and Codex CLI (OpenAI-compatible) on one port and records every request to a local SQLite ledger — with a usage dashboard (per-upstream and per-model cost + error rates), a Prometheus `/metrics` endpoint, a `ledger summary` CLI, and an optional AES-256-GCM-encrypted ledger at rest. Local-first: no hosted control plane, and provider keys never leave the machine. Fits alongside existing entries like TokenWise and onWatch.

Repo: https://github.com/XZXY-AI/ccg-router

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries