### PR TITLE
Add usage to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [usage](https://github.com/aqua5230/usage) — macOS menu bar app that pins Claude Code and Codex quota, tokens, and cost to your screen. Reads a local statusLine hook (Claude Code) and JSONL session logs (Codex); no API calls. Includes HTML reports, a TUI mode, and 9 themes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
-- [usage](https://github.com/aqua5230/usage) — macOS menu bar app that pins Claude Code and Codex quota, tokens, and cost to your screen. Reads a local statusLine hook (Claude Code) and JSONL session logs (Codex); no API calls. Includes HTML reports, a TUI mode, and 9 themes.
+- [usage](https://github.com/aqua5230/usage) — macOS menu bar and Windows tray app that pins Claude Code, Codex, and Antigravity quota, tokens, and cost to your screen. Claude Code and Codex are read from a local statusLine hook and JSONL session logs with no LLM API calls. Includes HTML reports, a TUI mode, and 9 themes.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [usage](https://github.com/aqua5230/usage), a macOS menu bar app that pins Claude Code and Codex quota, tokens, and cost to your screen. Local-only — reads a statusLine hook (Claude Code) and JSONL session logs (Codex); no API calls.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries