### PR TITLE
Add A3M Router - open-source LLM gateway with parallel execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,11 @@ Tools for monitoring token usage and API costs across AI providers:
 
 ---
 
+### Gateways & API Routing
+
+Tools that route between multiple LLM providers for cost optimization and reliability:
+
+- [A3M Router](https://github.com/Das-rebel/a3m-router) — Open-source LLM router that runs queries across 47+ providers in parallel with confidence scoring. 62% cost savings, 99.5% routing accuracy, independent benchmark validated. 19.5 KB CLI, zero ML dependencies.
 ## Specialized Tools
 
 ### Git & Commit Helpers


### PR DESCRIPTION
## Description
Add [A3M Router](https://github.com/Das-rebel/a3m-router) to a new Gateways & API Routing section under Agent Infrastructure.

A3M Router is an open-source LLM router with parallel multi-LLM execution across 47+ providers. Unlike sequential fallback approaches, A3M runs providers simultaneously with confidence voting, achieving 62% cost savings and 99.5% routing accuracy. Independently benchmarked (docs/BENCHMARK.md).

## Checklist
- [x] The repo URL is valid and the project is actively maintained
- [x] The description is factual and not promotional
- [x] The project is open-source (MIT license)
- [x] I have placed the entry in the correct category
- [x] My entry follows the list formatting
- [x] I have checked that this project is not already listed
