### PR TITLE
Add A3M Router — #1 LLM routing benchmark CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
 
 ### CLI Utilities
+- [A3M Router](https://github.com/Das-rebel/a3m-router) — CLI and programmatic LLM router that runs 47+ providers in parallel with confidence-scored ensemble voting. Routes every query to the cheapest capable model. #1 on RouterArena benchmark (76.43). Supports deep thinking, code, and creative presets. Open source (MIT), 19.5KB, zero ML dependencies. `npx a3m-router route "your query"`
 
 Lightweight command-line tools for AI-assisted commits, shell translation, and workflow automation:
 


### PR DESCRIPTION
## Description

Adds A3M Router to the CLI Utilities section. A3M Router is a CLI and programmatic LLM router that runs 47+ providers in parallel with confidence-scored ensemble voting, routing every query to the cheapest capable model.

**Quick start:** `npx a3m-router route "your query"`

## Checklist

- [x] The entry is a tool that uses AI — Routes queries across 47+ AI providers (OpenAI, Anthropic, Groq, DeepSeek, NVIDIA, etc.)
- [x] The entry is a developer-focused tool — CLI tool with TypeScript/Node.js API, zero-config auto-detection of API keys
- [x] The description is unambiguous and clear — Matches existing entry style with em-dash, link, and brief description
- [x] The description matches the style of other entries — Follows the same format as existing CLI utilities

**Benchmark:** #1 on RouterArena (76.43), cheapest at $0.047/1K queries.
**GitHub:** https://github.com/Das-rebel/a3m-router
**npm:** https://www.npmjs.com/package/adaptive-memory-multi-model-router