### PR TITLE
Add tokenscope

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [tokenscope](https://github.com/wartzar-bee/tokenscope) — Local, read-only CLI that parses Claude Code session logs to attribute spend across model output, re-sent cached context, and new context, with a per-turn context-growth curve and concrete trim-it insights. Zero network, zero telemetry.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **tokenscope** to *Usage Analytics & Cost Tracking*. It's a local, read-only CLI that parses Claude Code session logs to show not just usage totals but **where** the spend goes — model output vs. re-sent (cached) context vs. new context — plus a per-turn context-growth curve. It differs from the existing trackers/leaderboards in that section by focusing on cost *attribution* (e.g. surfacing how much of a bill is re-sent cached context). MIT, runs fully locally, zero network, zero telemetry.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
