### PR TITLE
Add SlimSnap to Desktop & Mobile Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [OpenQuack](https://github.com/larryxiao/openquack) - Privacy-first local voice dictation menu bar app for macOS. Pairs with Claude Code, Cursor, Codex, and Aider to dictate long contextual prompts; transcribes via WhisperKit on Apple Silicon, pastes at the cursor, ~8 MB, MIT.
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
+- [SlimSnap](https://slimsnap.ai/) — Native macOS app that converts annotated screenshots into structured JSON for terminal AI coding agents (Claude Code, Aider, Codex CLI). About 700 tokens per capture vs about 8000 vision tokens for the raw image. Ships with an open MIT Claude Code skill that auto-discovers the latest capture via ~/.slimsnap/config.json.
 
 ---
 


### PR DESCRIPTION
## Description

SlimSnap is a native macOS app that converts annotated screenshots into structured JSON for terminal AI coding agents like Claude Code, Aider, Codex CLI, and Cursor CLI. About 700 tokens per capture instead of about 8000 vision tokens for the raw image — 92 percent fewer tokens per turn.

This is squarely a developer tool, not a general purpose AI assistant or framework: it exists specifically to make terminal coding agents act on UI bugs and frontend work without burning vision tokens or context budget. The companion Claude Code skill (https://github.com/bickov/slimsnap-skill, MIT) auto-discovers the latest capture via ~/.slimsnap/config.json so "fix this" works without a slash command or upload step.

OCR runs on-device via Apple Vision. Nothing leaves the machine. Schema is JSON Schema 2020-12, open MIT. App is signed, Apple-notarized, free during launch.

- App: https://slimsnap.ai
- Schema (MIT): https://github.com/bickov/slimsnap-schema
- Skill (MIT): https://github.com/bickov/slimsnap-skill


## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
