### PR TITLE
Add Inference Labs under Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [Inference Labs](https://inference-labs.com) - Vendor-neutral LLM router and cost-control layer for production apps. Routes across OpenAI/Azure, Anthropic, Google, and Bedrock by policy (cost/quality/latency), with trace logging, eval suites, and open pricing API (`/api/prices.json`) for transparent cost comparisons.
 
 ---
 


### PR DESCRIPTION
## Description

Add **Inference Labs** in `Usage Analytics & Cost Tracking` as a developer-focused AI tool for LLM routing and spend control.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
