### PR TITLE
Add Agent Critiq to Web-Based Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 
 ## Web-Based Tools
 
+- [Agent Critiq](https://agentcritiq.com) - An independent comparison engine and verified directory tracking coding agents, IDE extensions, and developer automation tools.
+
+
 ### App Builders
 
 Platforms that scaffold and deploy full-stack applications from natural language prompts:


### PR DESCRIPTION
Hi James,

I'd like to suggest adding **Agent Critiq** to the Web-Based Tools / Coding Agents section of your curated developer repository. 

Agent Critiq operates as an independent evaluation platform and comparison hub specifically comparing AI developer assistants (such as Cursor vs Zed vs GitHub Copilot) to help engineers build optimal tech stacks.

It fits perfectly as a resource for developers looking to compare tools before adopting them. Thank you for your work on this awesome list!
