### PR TITLE
Add AutoMaxFix (CI/CD & Testing Automation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [AutoMaxFix](https://github.com/Noumenon-ai/AutoMaxFix) — CLI reliability layer for AI-built projects: turns test failures and runtime drift into tickets, repairs one at a time behind a human approval gate, and validates each fix with targeted and regression tests. Open source (MIT), Python.
 
 ---
 


### PR DESCRIPTION
Adds AutoMaxFix under Automated Workflows > CI/CD & Testing Automation.

AutoMaxFix is an open-source (MIT) Python CLI reliability layer for AI-built projects: it turns test-runner failures (pytest, jest, vitest, mocha, go, cargo) and runtime drift into structured tickets, drives a local agent CLI (Codex/Claude) through a strict patch contract to repair one ticket at a time behind a human approval gate, and validates every fix with targeted + regression tests. It also re-verifies passed fixes and raises a linked regression ticket when one stops holding.

Repo: https://github.com/Noumenon-ai/AutoMaxFix