### PR TITLE
Add AgentDiff to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [AgentDiff](https://www.agentdiff.site) — Git-native provenance for AI-written code. Records which AI agent wrote which line across Claude Code, Cursor, Copilot, Codex, Windsurf, OpenCode, and Gemini, reconciles it against each commit, and signs every attribution with ed25519. Local-first — records live in your own git history, no server.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adds **AgentDiff** to the Codebase Intelligence section — an open-source, git-native tool that records which AI coding agent wrote which line of code (Claude Code, Cursor, Copilot, Codex, Windsurf, OpenCode, Gemini), reconciles attribution against each commit, and signs every record with ed25519. Local-first: records live in your own git history, no server.

Maker here — early, solo-built, OSS core.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries