### PR TITLE
Add Open Code Review to PR & Code Review Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Integrations that automatically review pull requests and suggest code fixes:
 - [PR Triage](https://pr-triage-web.vercel.app) — Open source PR evaluation tool that scores pull requests on six quality dimensions with diff evidence. BYOK, MIT licensed.
 - [prpack-action](https://github.com/Lucas2944/prpack-action) — GitHub Action that runs prpack on every PR, uploads the packed markdown as an artifact, and posts a summary comment. MIT.
 - [Issue AI Agent](https://github.com/alexyan0431/issue-ai-agent) — Open source GitHub Action that auto-classifies, labels, and replies to issues using AI. Detects duplicates and handles follow-up comments. Supports Claude, OpenAI, and OpenAI-compatible APIs (BYOK). MIT licensed.
+- [Open Code Review](https://github.com/alibaba/open-code-review) — Hybrid architecture code review tool combining deterministic pipelines with LLM Agent. Battle-tested at Alibaba's scale with built-in fine-tuned ruleset and precise line-level comments.
 
 ### CI/CD & Testing Automation
 


### PR DESCRIPTION
## Summary

- Add [Open Code Review](https://github.com/alibaba/open-code-review) to the **PR & Code Review Bots** section.

Open Code Review is a hybrid architecture code review tool combining deterministic pipelines with LLM Agent. Battle-tested at Alibaba's scale with built-in fine-tuned ruleset and precise line-level comments.

- Homepage: https://alibaba.github.io/open-code-review/
- GitHub: https://github.com/alibaba/open-code-review