### PR TITLE
Add Agent CLI Menu to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [Agent CLI Menu](https://github.com/roypadina/AgentCliMenu) — macOS TUI and menu-bar app to start or resume Claude Code and Codex sessions; frecency project launcher plus full-transcript fuzzy search across past sessions, with a working-directory confidence gate. MIT.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [Agent CLI Menu](https://github.com/roypadina/AgentCliMenu) to **Terminal → CLI Utilities** — a free, open-source (MIT) macOS TUI and menu-bar app to start or resume Claude Code / Codex coding-agent sessions. It gives a frecency-sorted project launcher on the New side, and on the Resume side full-transcript fuzzy search across every past session with an inline transcript peek and a working-directory confidence gate. Placed in CLI Utilities (rather than Terminal Agents) since it manages/launches agent sessions rather than autonomously generating code. `brew install --cask roypadina/tap/agentclimenu`. Disclosure: I'm the author.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries