### PR TITLE
feat: add TWZRD Agent Intel — agent identity verification MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [claude-code-pro-pack](https://github.com/sisyphusse1-ops/claude-code-pro-pack) — Drop-in 12-rule `CLAUDE.md` + `AGENTS.md` baseline that closes common agent-orchestration failures (token spirals, silent partial failures, two-pattern pollution). Includes PRD generator prompt, browser-skill-graduation workflow, and 5 example skills. ~700 tokens total, MIT.
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server providing on-chain trust scoring for AI agents on Solana. Free tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`. Paid: `get_trust_receipt` (x402 micropayment, <1s USDC settlement). Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`.
 
 ### Usage Analytics & Cost Tracking
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,8 @@ Tools for monitoring token usage and API costs across AI providers:
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) — Solana-native MCP server for agent identity verification and trust scoring in multi-agent systems. Preflight trust checks before agent-to-agent transactions, signed `twzrd.receipt.v5` audit receipts via HTTP 402 + USDC micropayment (<1s settlement). Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
+
 ---
 
 ## Specialized Tools


### PR DESCRIPTION
## What this adds

[TWZRD Agent Intel](https://intel.twzrd.xyz) — a Solana-native MCP server for agent identity verification and trust scoring in multi-agent systems.

Added to **Agent Infrastructure > Usage Analytics & Cost Tracking** as it provides pre-dispatch trust checks and signed audit receipts for agent transactions.

## Details

- **Zero-install MCP config**: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
- **Free tools**: Score any Solana wallet — on-chain activity, tx patterns, network age, recurring behavior
- **Paid tool**: `get_trust_receipt` returns signed `twzrd.receipt.v5` via HTTP 402 + USDC micropayment (<1s settlement)

## Use case

When AI coding agents (Claude Code, Codex, etc.) orchestrate downstream agent-to-agent calls or API transactions, TWZRD provides:
- Preflight identity checks before sending requests to unknown agents
- Signed audit receipts for compliance and cost tracking
- Trust scoring to route high-value tasks to verified agents only

MCP Registry: `xyz.twzrd.intel/twzrd-agent-intel`