### PR TITLE
feat: add TWZRD Agent Intel — Solana agent identity verification MCP for developer workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [claude-code-pro-pack](https://github.com/sisyphusse1-ops/claude-code-pro-pack) — Drop-in 12-rule `CLAUDE.md` + `AGENTS.md` baseline that closes common agent-orchestration failures (token spirals, silent partial failures, two-pattern pollution). Includes PRD generator prompt, browser-skill-graduation workflow, and 5 example skills. ~700 tokens total, MIT.
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) — MCP server providing on-chain trust scoring for AI agents on Solana. Free tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`. Paid: `get_trust_receipt` (x402 micropayment, <1s USDC settlement). Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`.
 
 ### Usage Analytics & Cost Tracking
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,8 @@ Tools for monitoring token usage and API costs across AI providers:
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) — Solana-native MCP server for agent identity verification and trust scoring in multi-agent systems. Preflight trust checks before agent-to-agent transactions, signed `twzrd.receipt.v5` audit receipts via HTTP 402 + USDC micropayment (<1s settlement). Zero-install: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`
+
 ---
 
 ## Specialized Tools


### PR DESCRIPTION
## Description

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Agent Infrastructure > Usage Analytics & Cost Tracking** section.

TWZRD Agent Intel is a Solana-native MCP server that developers use to verify agent identity and trust before executing agent-to-agent API calls or transactions in production multi-agent workflows. It provides:

- **4 free tools**: Score any Solana wallet — on-chain activity, tx patterns, network age, recurring behavior
- **Paid audit receipts**: `get_trust_receipt` returns signed `twzrd.receipt.v5` via HTTP 402 + USDC (<1s settlement)
- **Zero-install MCP endpoint**: `https://intel.twzrd.xyz/mcp`

This is developer infrastructure — the MCP server is configured via `mcpServers` config and called directly from Claude Code, Codex, or any MCP-compatible agent framework to preflight agent-to-agent requests.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries