### PR TITLE
Add Selvedge to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [Selvedge](https://github.com/masondelan/selvedge) — Local MCP server that captures the reasoning behind every AI-written code change. Query with `selvedge blame` for entity-level history with the original prompt context, or `prior_attempts` so the agent reads prior reasoning before it edits. Open source (MIT), Python 3.10+, all data local.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adding **Selvedge** to the **Codebase Intelligence** section — a local MCP server that captures the reasoning behind every AI-written code change. AI coding agents call it as they work to log structured change events (entity + diff + reasoning) to a local SQLite database, then query history with `selvedge blame`, or `prior_attempts` so the agent reads prior reasoning before it edits.

- Open source (MIT), Python 3.10+, `pip install selvedge`
- v0.3.7 latest, pytest/ruff/mypy all green
- Works with Claude Code, Cursor, and Copilot — `selvedge setup` detects and configures all three
- All data stays local (SQLite under `.selvedge/`); no telemetry
- Seven tools: `log_change`, `diff`, `blame`, `history`, `changeset`, `search`, `prior_attempts`

Closest peer in the list is `sourcebook` — both are CLI+MCP for codebase context; Selvedge complements it on the change-history axis (event log + reasoning).

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
