### PR TITLE
Add 8080.ai to App Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Platforms that scaffold and deploy full-stack applications from natural language
 - [Blank Space](https://www.blankspace.build/) — Open-source AI app builder for creating web applications using natural language. Self-hostable alternative to v0, Lovable, and Bolt.
 - [Fastshot](https://fastshot.ai/) — AI driven no-code platform for building and deploying mobile apps.
 - [ai-vertical-saas-gen](https://github.com/kurtnebiev-elvis4/ai-vertical-saas-gen) — CLI that generates complete vertical SaaS apps (Next.js 14 + Supabase) with industry-specific data models for 20+ niches. Zero dependencies, offline, outputs 20 deployable files in one command.
+- [8080AI](https://8080.ai/) — Architecture-first multi-agent platform that generates production-ready, full-stack applications from a single prompt using specialized parallel agents.
 
 ### UI Generators
 


### PR DESCRIPTION
## Description

Adds [8080AI](https://8080.ai/) to App Builders. It's an architecture-first, multi-agent AI development platform that generates production-ready, full-stack applications from a single prompt using specialized parallel agents.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries