### PR TITLE
Add TokenKnows to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [claude-code-pro-pack](https://github.com/sisyphusse1-ops/claude-code-pro-pack) — Drop-in 12-rule `CLAUDE.md` + `AGENTS.md` baseline that closes common agent-orchestration failures (token spirals, silent partial failures, two-pattern pollution). Includes PRD generator prompt, browser-skill-graduation workflow, and 5 example skills. ~700 tokens total, MIT.
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
+- [TokenKnows](https://github.com/johnnywuj81/tokenknows) — Self-hosted knowledge workbench that captures dev events and sessions from Claude Code, Codex, Cursor, VS Code, and GitHub, then distills them into weekly reports, ADRs, incident reviews, and a knowledge graph via a 5-stage LLM pipeline. Ships an MCP server, Claude Code and Codex plugins, and a VS Code extension. MIT.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds **TokenKnows** to Agent Infrastructure → Configuration & Context Management.

TokenKnows is a self-hosted, MIT-licensed engineering knowledge workbench for developers using AI coding tools. It captures dev events and sessions from Claude Code, Codex, Cursor, VS Code, and GitHub, and distills them into weekly reports, ADRs, incident reviews, and a knowledge graph via a 5-stage LLM pipeline. It ships an MCP server, a Claude Code plugin, a Codex plugin, and a VS Code extension — placing it alongside the section's other agent knowledge/context tools (Nex, SwarmVault, AgentsKB).

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries