### PR TITLE
Add Nanocoder to Terminal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
+- [Nanocoder](https://github.com/Nano-Collective/nanocoder) — Local-first, open-source terminal coding agent built by a community collective. Bring your own model (Ollama, OpenRouter, or any OpenAI-compatible API) and keep your code on your machine. Native tool calling with XML fallback, MCP support, and file-based custom commands and tools.
 
 ### CLI Utilities
 


### PR DESCRIPTION
## Description

Adds [Nanocoder](https://github.com/Nano-Collective/nanocoder) to Terminal > Terminal Agents. It is a local-first, open-source terminal coding agent: bring your own model (Ollama, OpenRouter, or any OpenAI-compatible API), with native tool calling, an XML fallback, and MCP support.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

Appended to the bottom of the Terminal Agents subsection; GitHub link verified.