### PR TITLE
Add Headroom — native macOS Claude Code usage monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [Headroom](https://github.com/patwalls/headroom) — Free native macOS menu bar app showing Claude Code session (5h) and weekly (7d) usage as a live %, color-coded before limits hit. Zero network calls, MIT.
 
 ---
 


### PR DESCRIPTION
Headroom is a free native macOS menu bar app that shows Claude Code's session (5h) and weekly (7d) usage limits as a live percentage, color-coded as limits approach.

**Why it fits the Usage Analytics & Cost Tracking section:**
- Monitors Claude Code session and weekly utilization
- Shows reset countdowns and session cost
- Zero network calls — reads a local file written by Claude Code's own status line hook (no API polling)
- Native Swift, MIT license, signed & notarized

**Links:**
- GitHub: https://github.com/patwalls/headroom
- Site: https://headroom.walls.sh
- Brew: `brew install --cask patwalls/tap/headroom`