### PR TITLE
Add Remio

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [claude-code-pro-pack](https://github.com/sisyphusse1-ops/claude-code-pro-pack) — Drop-in 12-rule `CLAUDE.md` + `AGENTS.md` baseline that closes common agent-orchestration failures (token spirals, silent partial failures, two-pattern pollution). Includes PRD generator prompt, browser-skill-graduation workflow, and 5 example skills. ~700 tokens total, MIT.
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
+- [Remio](https://remio.ai/) — CLI-accessible local knowledge base for AI agents. Parses files, webpages, recordings, emails, messages, images, and notes into local indexes and vectors so agents can retrieve relevant context without repeated folder scans or token-heavy whole-file loading.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds Remio under Configuration & Context Management as a developer/agent context retrieval tool.

Remio provides a CLI-accessible local knowledge base for AI agents. It parses files, webpages, recordings, emails, messages, images, and notes into local indexes and vectors so agents can retrieve relevant context without repeated folder scans or token-heavy whole-file loading.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries