### PR TITLE
Add agentic-harness (Configuration & Context Management)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [agentic-harness](https://github.com/MrBogomips/agentic-harness) — Claude Code plugin that builds, reviews, and maintains a project's agentic harness (the agents, skills, and orchestrator under .claude/), coordinating with existing spec-driven-development systems and issue trackers and optionally syncing a repo-native tracker with Jira/Linear. MIT.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds **agentic-harness** under **Agent Infrastructure → Configuration & Context Management**, alongside tools like Caliber, ContextKit, and the GAAI Framework that generate and maintain AI-agent configuration.

[agentic-harness](https://github.com/MrBogomips/agentic-harness) is an MIT-licensed Claude Code plugin that builds, reviews, and maintains a project's `.claude/` agent harness — the agents, skills, and orchestrator — coordinating with a project's existing spec-driven-development system and issue tracker, and optionally syncing a repo-native tracker with Jira/Linear. It is a developer configuration/context tool, **not** a general-purpose agent or framework.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries