### PR TITLE
Add Herdr to Agent Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Platforms for running multiple AI coding agents in parallel with workspace isola
 
 - [Conductor](https://conductor.build/) — macOS app for orchestrating multiple Claude Code and Codex agents working simultaneously in isolated git worktrees. Features a central dashboard for monitoring, code review, and merging.
 - [Superset](https://superset.sh/) — Code editor for AI agents that orchestrates swarms of Claude Code, Codex, and other CLI-based agents in parallel. Uses isolated git worktrees with universal IDE integration.
+- [Herdr](https://herdr.dev/) — Agent multiplexer that lives in your terminal. Workspaces, tabs, panes. mouse-native: click, drag, split. every agent at a glance: blocked, working, done. detach and reattach, agents keep running. no gui app, no electron, no mac-only native wrapper. you see the agent's own terminal, not someone's interpretation of it.
 - [Sidecar](https://github.com/marcus/sidecar) — Terminal UI companion for CLI-based coding agents (Claude Code, Cursor, Gemini) with unified conversation history, git integration, task management, and workspace control.
 - [Vibe Kanban](https://vibekanban.com/) — AI-powered Kanban platform for orchestrating autonomous coding agents. Manage agent workflows with visual boards for task delegation and progress tracking.
 - [OpenASE](https://github.com/pacificstudio/openase) — Open-source ticket-driven platform for orchestrating Claude Code, Codex, and Gemini CLI agents across isolated workspaces and status-based workflows.


### PR DESCRIPTION
Added a new platform 'Herdr' for AI agent orchestration.


## Checklist verified

- The entry is a tool that uses AI
- The entry is a developer-focused tool
- The description is unambiguous and clear
- The description matches the style of other entries
