### PR TITLE
Add Source Trace to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [Source Trace](https://srctrace.com) — AI git blame for every commit: see which lines came from AI and which model wrote them. Compare models by amount of code written pre-commit, committed, and survived in codebase. Teams can use dashboard to track adoption and AI metrics. Zero-config VS Code extension, no git or agent hooks required.
 
 ---
 


### PR DESCRIPTION
Source Trace is a developer tool that adds AI git blame to every commit — tracking which lines came from AI and which model wrote them. It fits the Usage Analytics & Cost
  Tracking section alongside similar tools.

  - [x] The entry is a tool that uses AI
  - [x] The entry is a developer-focused tool
  - [x] The description is unambiguous and clear
  - [x] The description matches the style of other entries