### PR TITLE
Add AccInt to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [claude-code-pro-pack](https://github.com/sisyphusse1-ops/claude-code-pro-pack) — Drop-in 12-rule `CLAUDE.md` + `AGENTS.md` baseline that closes common agent-orchestration failures (token spirals, silent partial failures, two-pattern pollution). Includes PRD generator prompt, browser-skill-graduation workflow, and 5 example skills. ~700 tokens total, MIT.
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
+- [AccInt](https://github.com/maxbaluev/accreted-intelligence) — Local-first learning substrate and MCP server for Claude Code, Codex, OpenCode, and Cursor. It builds a Work Model from what actually worked — graded by real outcomes, not the model's own word — and predicts the better path, so the same job gets faster and lands better every run.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds **AccInt** to **Agent Infrastructure → Configuration & Context Management**.

AccInt is a local-first, developer-focused learning substrate (and MCP server) that slots under coding agents — Claude Code, Codex, OpenCode, and Cursor. It builds a Work Model from what actually worked — graded by real outcomes, not the model's own word — and predicts the better path, so the same coding job gets faster and lands better every run. It fits alongside the existing cross-session memory / context tools in this section (e.g. Nex, GAAI Framework).

Repo: https://github.com/maxbaluev/accreted-intelligence

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
