### PR TITLE
Add DocPulse to Documentation Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Tools that auto-generate documentation, diagrams, and changelogs from source cod
 - [DocuWriter.ai](https://www.docuwriter.ai/) — AI-powered web app to generate automated Code & API documentation from your source code files.
 - [EkLine](https://ekline.io/) — AI-powered documentation tool with quality checks, style guide enforcement, and automatic doc generation.
 - [Changenotes](https://changenotes.app) — AI-powered changelog generator. Connects to GitHub, auto-generates categorized changelogs from commits and PRs on every release. Free tier available, Pro $9/mo.
+- [DocPulse](https://github.com/YoniRaviv/DocPulse) — Open-source GitHub Action that detects documentation invalidated by a PR's code changes and commits surgical, style-preserving fixes onto the PR branch. A deterministic tree-sitter link graph picks suspect doc sections; an LLM verifier and repairer handle the rest. Supports Claude, OpenAI, and any LiteLLM model (BYOK). MIT licensed.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **DocPulse** to the *Specialized Tools → Documentation Generation* section. It could also fit *PR & Code Review Bots* (it's a PR-triggered bot) — happy to move it if you'd prefer that section.

[DocPulse](https://github.com/YoniRaviv/DocPulse) is an open-source (MIT) GitHub Action that keeps technical docs in sync with code: on each PR it detects documentation sections invalidated by the code changes and commits surgical, style-preserving fixes onto the PR branch. A deterministic tree-sitter link graph selects suspect doc sections; an LLM verifier decides stale-or-not and a repairer applies the fix. Works with Claude, OpenAI, or any LiteLLM model (BYOK).

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries