### PR TITLE
Add ultracost to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [ultracost](https://github.com/danielkremen818/ultracost) — Per-stage model routing and a pre-flight cost gate for Claude Code `ultracode` dynamic workflows. A static guard flags any `agent()` subagent stage that would silently inherit the session's Opus model; a deterministic PreToolUse gate estimates the run and stops the launch for approval; and it reconciles its estimate against real per-stage token usage. Zero dependencies, no telemetry, MIT.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **ultracost** to **Usage Analytics & Cost Tracking** (alongside peers like TokenWise). ultracost is per-stage model routing and a pre-flight cost gate for Claude Code `ultracode` dynamic workflows: a static guard flags any `agent()` subagent stage that would silently inherit the session's Opus model, a deterministic PreToolUse gate estimates the run and stops the launch for approval, and it reconciles its estimate against real per-stage token usage. Single bullet appended to the existing section; format matches surrounding entries. Repo: https://github.com/danielkremen818/ultracost (zero dependencies, no telemetry, MIT).

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries