### PR TITLE
Add Tokonomics - budget-first AI cost metering proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
-
+- [Tokonomics](https://tokonomics.ca) — Budget-first AI cost metering proxy. Sits between your app and any LLM provider (OpenAI, Anthropic, DeepSeek, Gemini, xAI), tracks every token, enforces hard spending caps via Redis, and sends budget alerts via email, Slack, or Teams. Language-agnostic — works with any HTTP client.
 ---
 
 ## Specialized Tools


### PR DESCRIPTION
## Description

<!-- Please provide a brief description of the changes in this PR -->

Adds [Tokonomics](https://tokonomics.ca) to the "Tools for monitoring token usage and API costs" section. Tokonomics is a budget-first AI cost metering proxy that sits between your app and any LLM provider (OpenAI, Anthropic, DeepSeek, Gemini, xAI). It tracks every token, enforces hard spending caps via Redis (sub-1ms), and sends budget alerts via email, Slack, or Teams. Language-agnostic — works with any HTTP client. Free tier available.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries