### PR TITLE
Add Beever Atlas — team knowledge base with MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [Beever Atlas](https://github.com/Beever-AI/beever-atlas) — Open-source team knowledge base with native MCP server (16 tools). Ingests Slack, Discord, Teams, and Telegram into a typed Neo4j knowledge graph with cited answers, semantic search, expert finding, and decision tracing. BYO LLM via LiteLLM, Apache 2.0, on-prem via Docker.
 
 ### Database & SQL
 


### PR DESCRIPTION
Adds Beever Atlas to the **Codebase Intelligence** section.

**What it is:** Open-source team LLM knowledge base that ingests Slack, Discord, Teams, and Telegram chat into a typed Neo4j knowledge graph, then exposes it as a native MCP server (16 tools) so AI coding assistants can query team knowledge — cited answers, semantic search, expert finding, and decision tracing.

**Why it fits Codebase Intelligence:** Similar to Unblocked (which connects GitHub, Slack, Jira, Confluence), Beever Atlas makes team context queryable for AI dev tools. The difference is it builds a persistent knowledge graph rather than just search.

**Quick facts:**
- Apache 2.0 license
- Native MCP server with 16 tools
- BYO LLM via LiteLLM (Ollama, Qwen, Claude, GPT, Gemma)
- Typed Neo4j graph + Weaviate dual-store
- Multimodal (Jina v4)
- On-prem via Docker, no cloud dependency
- 380+ GitHub stars

Repo: https://github.com/Beever-AI/beever-atlas

Happy to adjust the entry or move it to a different section if you think there's a better fit. Thanks for maintaining this list!