### PR TITLE
Add Beever Atlas to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [Beever Atlas](https://github.com/Beever-AI/beever-atlas) — Open-source team knowledge base with native MCP server (16 tools). Ingests Slack, Discord, Teams, and Telegram into a typed Neo4j knowledge graph with cited answers, semantic search, expert finding, and decision tracing. BYO LLM via LiteLLM, Apache 2.0, on-prem via Docker.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adding Beever Atlas to the **Codebase Intelligence** section. It's an open-source team knowledge base (Apache 2.0) that ingests Slack, Discord, Teams, and Telegram into a typed Neo4j knowledge graph, then exposes it as a native MCP server (16 tools) so AI coding assistants can query team knowledge — cited answers, semantic search, expert finding, and decision tracing. BYO LLM via LiteLLM, on-prem via Docker.

Similar to Unblocked (which connects GitHub, Slack, Jira, Confluence for codebase context), Beever Atlas makes team discussions and decisions queryable for AI dev tools — but with a persistent typed knowledge graph backend.

GitHub: https://github.com/Beever-AI/beever-atlas (380+ stars)

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries