### PR TITLE
Add Playcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Platforms that scaffold and deploy full-stack applications from natural language
 - [Forge](https://forge-web.rebaselabs.online) — AI-powered full-stack app creator that generates Next.js apps from natural language. BYOK model — use your own Anthropic, OpenAI, or Google AI key with no markup. Multi-stage pipeline with auto-fix and TypeScript strict mode.
 - [e2b_Fragments](https://fragments.e2b.dev/) — Platform for building and deploying AI-powered applications with sandboxed environments.
 - [Mocha](https://getmocha.com/) — AI-powered no-code application builder for creating web apps without writing code.
+- [Playcode](https://playcode.io/ai-website-builder) - AI app and website builder with visual editing, hosted deployments, and custom domains.
 - [Pythagora](https://www.pythagora.ai/) — AI development platform with 14 specialized agents that builds React/Node.js apps from natural language. Integrates with VS Code and Cursor with one-click deployment.
 - [Mage](https://usemage.ai/) — Generate full-stack web apps in Wasp, React, Node.js and Prisma.
 - [Make Real](https://makereal.tldraw.com/) — Online canvas that can be used to generate HTML/JavaScript apps.


### PR DESCRIPTION
## Description

Adds Playcode to Web-Based Tools > App Builders. It fits this section as an AI app and website builder with hosted deployments, visual editing, and custom domains.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries