### PR TITLE
Add Tintpad (Desktop & Mobile Applications)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
 - [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
+- [Tintpad](https://github.com/sorkila/tintpad) — Native macOS menu-bar launcher: one hotkey opens your terminal at the right repo with Claude Code, Codex, or any agent already running. Frecency repo search, run modes (Safe/Default/YOLO), git worktrees, headless dispatch. Local-only, free, open source (MIT).
 
 ---
 


### PR DESCRIPTION
Adds **Tintpad**, a native macOS menu-bar launcher: one hotkey opens your terminal at the right repo with Claude Code, Codex, or any agent already running. Frecency repo search, run modes, git worktrees, headless dispatch. Local-only, free, MIT, signed + notarized.

https://github.com/sorkila/tintpad

Fits alongside Clave / Vibe Island / Parallel Code in Desktop & Mobile Applications. Thanks!