### PR TITLE
Add PR Focus to PR & Code Review Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Integrations that automatically review pull requests and suggest code fixes:
 - [PR Triage](https://pr-triage-web.vercel.app) — Open source PR evaluation tool that scores pull requests on six quality dimensions with diff evidence. BYOK, MIT licensed.
 - [prpack-action](https://github.com/Lucas2944/prpack-action) — GitHub Action that runs prpack on every PR, uploads the packed markdown as an artifact, and posts a summary comment. MIT.
 - [Issue AI Agent](https://github.com/alexyan0431/issue-ai-agent) — Open source GitHub Action that auto-classifies, labels, and replies to issues using AI. Detects duplicates and handles follow-up comments. Supports Claude, OpenAI, and OpenAI-compatible APIs (BYOK). MIT licensed.
+- [PR Focus](https://chromewebstore.google.com/detail/pr-focus-ai-pro/ememaiabefeojkccjclglcmbjmdpnaoe) — Chrome extension that prioritizes GitHub PRs with AI risk scoring (0–100), summarizes diffs, and drafts approve/request-changes reviews in one click. BYOK (OpenAI, Groq, Mistral, Ollama). Free tier, one‑time $9.50 PRO.
 
 ### CI/CD & Testing Automation
 


### PR DESCRIPTION
## Description

Adds PR Focus, a Chrome extension that adds AI-prioritized triage to the GitHub PR inbox — risk scoring, diff summaries, and one-click draft reviews. BYOK (no proprietary backend in the data path), consistent with other BYOK tools already listed in this section (PR Triage, Issue AI Agent).

<!-- Please provide a brief description of the changes in this PR -->

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
