### PR TITLE
Add agent-runbook to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 
 Platforms for running multiple AI coding agents in parallel with workspace isolation:
 
+- [agent-runbook](https://github.com/KnoxOps/agent-runbook) — Python CLI that compiles contract-based YAML runbooks into SKILL.md files for Claude Code and Codex agents. Define multi-step workflows with loops (goal-driven, max-iteration bounded), parallel fan-out, conditional branching, and checkpoint-based resume — broken runs pick up where they left off instead of starting over.
 - [Conductor](https://conductor.build/) — macOS app for orchestrating multiple Claude Code and Codex agents working simultaneously in isolated git worktrees. Features a central dashboard for monitoring, code review, and merging.
 - [Superset](https://superset.sh/) — Code editor for AI agents that orchestrates swarms of Claude Code, Codex, and other CLI-based agents in parallel. Uses isolated git worktrees with universal IDE integration.
 - [Sidecar](https://github.com/marcus/sidecar) — Terminal UI companion for CLI-based coding agents (Claude Code, Cursor, Gemini) with unified conversation history, git integration, task management, and workspace control.


### PR DESCRIPTION
## Description

Add agent-runbook to the Multi-Agent Orchestration section.

agent-runbook is a Python CLI that compiles YAML runbooks into executable SKILL.md files for Claude Code and Codex agents. Unlike coordination platforms that manage live agent sessions, agent-runbook is a build-time compiler — you define the workflow as a YAML DAG with typed input/output contracts, it validates contract closure, and produces a SKILL.md that agents execute step by step with file-based state passing between stages.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries