### PR TITLE
Add Falconer to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [Falconer](https://falconer.com/mcp) — Remote MCP server that gives AI coding agents trusted access to a company's living documentation. Search, read, and update source-of-truth engineering docs, runbooks, decisions, and code context. Works with Claude Code, Cursor, Codex, and other MCP clients.
 
 ### Database & SQL
 


### PR DESCRIPTION
Adds **Falconer** to **Web-Based Tools → Codebase Intelligence** (alongside Unblocked and the other MCP servers there).

Falconer is a remote MCP server that gives AI coding agents trusted access to a company's living documentation — search, read, and update engineering docs, runbooks, decisions, and code context. Works with Claude Code, Cursor, Codex, and other MCP clients.

- Setup: https://falconer.com/mcp
- Repo: https://github.com/FalconerAI/agent-integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)