### PR TITLE
Add Meccha Chameleon Art fan atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,3 +439,8 @@ Curated lists, comparison guides, and configuration templates for AI coding tool
 - [AI Coding Guide (中文)](https://github.com/jnMetaCode/ai-coding-guide) — Chinese best practices for 8 AI coding tools (Claude Code, Cursor, Copilot, Windsurf, Gemini CLI, Kiro, Aider, Trae) with copy-paste config templates and multi-tool collaboration workflows.
 - [Claude Code Skills 中文精选集](https://claude-skills.bt199.com/) — Chinese curated directory of Claude Code Skills, agents, plugins, and workflow resources for developers using Claude Code.
 - [Awesome AI Startups — Coding & Developer Tools](https://github.com/nowork-studio/awesome-ai-startups#-coding--developer-tools) — 100+ indie-built AI coding assistants, dev tools, and code-generation products from bootstrapped, pre-seed, and angel-funded startups.
+
+## Community Resource Additions
+
+<!-- Added 2026-06-24 by zlc000190 -->
+- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser atlas of 50+ hiding spots for the Steam hide-and-seek game Meccha Chameleon. Bilingual (EN/中文), paint color analysis. GitHub awesome list: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot


### PR DESCRIPTION
## Description

Adds a community resource entry for the Meccha Chameleon Art fan atlas, a fan-made browser companion for the Steam hide-and-seek game Meccha Chameleon.

## Resource Added

- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser atlas of 50+ hiding spots, bilingual (EN/中文), with paint color analysis. Built with Next.js 14.
- GitHub awesome list: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot

## Checklist

- [x] Entry follows the awesome-list format
- [x] Resource is community-relevant
- [x] Links are valid and active
- [x] No spam/affiliate links
- [x] Fan-made disclaimer included (Meccha Chameleon is © LEMORION)