### PR TITLE
Add River Review to PR & Code Review Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Integrations that automatically review pull requests and suggest code fixes:
 - [Grit](https://app.grit.io) — GitHub-integrated agent for automating maintenance tasks and other development work.
 - [PR Triage](https://pr-triage-web.vercel.app) — Open source PR evaluation tool that scores pull requests on six quality dimensions with diff evidence. BYOK, MIT licensed.
 - [prpack-action](https://github.com/Lucas2944/prpack-action) — GitHub Action that runs prpack on every PR, uploads the packed markdown as an artifact, and posts a summary comment. MIT.
+- [River Review](https://github.com/s977043/river-review) — Open source, team-owned review layer: codify review judgment as repo-owned skills and run them across plans, diffs, tests, and prior reviews. Human-in-the-loop, not auto-merge.
 - [Issue AI Agent](https://github.com/alexyan0431/issue-ai-agent) — Open source GitHub Action that auto-classifies, labels, and replies to issues using AI. Detects duplicates and handles follow-up comments. Supports Claude, OpenAI, and OpenAI-compatible APIs (BYOK). MIT licensed.
 
 ### CI/CD & Testing Automation


### PR DESCRIPTION
Adds River Review to the PR & Code Review Bots section.

River Review is an open source, team-owned review layer: it codifies review judgment as repo-owned skills and runs them across plans, diffs, tests, and prior reviews. Human-in-the-loop, not auto-merge.

Repository: https://github.com/s977043/river-review