### PR TITLE
Add capcut-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [capcut-cli](https://github.com/renezander030/capcut-cli) — Zero-dependency CLI that reads and writes CapCut/JianYing draft files (JSON in, JSON out, no server), giving any LLM agent a deterministic boundary to build and edit videos: subtitles, Whisper auto-caption, and cutting long-form to shorts.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [capcut-cli](https://github.com/renezander030/capcut-cli) to **Terminal > CLI Utilities**.

A zero-dependency CLI that reads and writes CapCut / JianYing draft files directly (JSON in, JSON out, no server, no private API), giving any LLM agent a deterministic boundary to build and edit videos. It uses Whisper for auto-captioning, plus edits subtitles and cuts long-form into shorts. MIT, on npm, actively maintained.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
