### PR TITLE
Add podium-mcp to CI/CD & Testing Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [eval-harness](https://github.com/nano-step/eval-harness) — Behavior-regression testing for LLM agent skills. 4-class attribution, 6-field FAIL schema, $-cost gating, and GitHub Action for CI integration.
+- [OhMyPerf](https://github.com/nhoxtvt/ohmyperf) — Web performance measurement tool with Core Web Vitals, Lighthouse audits, and AI-powered fix suggestions. Measures LCP, INP, CLS with statistical significance testing.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -309,8 +309,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
-- [eval-harness](https://github.com/nano-step/eval-harness) — Behavior-regression testing for LLM agent skills. 4-class attribution, 6-field FAIL schema, $-cost gating, and GitHub Action for CI integration.
-- [OhMyPerf](https://github.com/nhoxtvt/ohmyperf) — Web performance measurement tool with Core Web Vitals, Lighthouse audits, and AI-powered fix suggestions. Measures LCP, INP, CLS with statistical significance testing.
+- [podium-mcp](https://github.com/hoainho/podium-mcp) — Mobile + canvas automation MCP server. 51 tools for iOS/Android device control, native UI automation, WebView DOM + network inspection, React Native debugging, and a no-vision canvas/WebGL brain. ~5x fewer tokens than screenshot/vision loops.
 
 ---
 


### PR DESCRIPTION
## Summary

Add [podium-mcp](https://github.com/hoainho/podium-mcp) to the CI/CD & Testing Automation section.

**podium-mcp** is a mobile + canvas automation MCP server:
- 51 tools for iOS/Android device control, native UI automation
- WebView DOM + network inspection, React Native debugging
- No-vision canvas/WebGL brain for game engines
- ~5x fewer tokens than screenshot/vision loops
- Single stdio endpoint replaces multiple MCP servers

## Checklist
- [x] Entry follows the existing format
- [x] Project is a CI/CD or testing tool
- [x] Repository is public and actively maintained