### PR TITLE
Add skillreaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [skillreaper](https://github.com/thousandflowers/skillreaper) — 100%-local Go CLI (`reap`) that scans your AI coding agent's session transcripts (Claude Code, Codex, and more) to find skills, MCP servers, and agents that load into context but never fire, quantifies the wasted tokens and cost, and reversibly prunes the dead weight. Single binary, zero telemetry.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds **skillreaper** to the **Configuration & Context Management** section. It is a 100%-local Go CLI (`reap`) that scans an AI coding agent's session transcripts (Claude Code, Codex, and more) to find skills, MCP servers, and agents that load into context but never fire, quantifies the wasted tokens and cost, and reversibly prunes the dead weight. Repo: https://github.com/thousandflowers/skillreaper

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
