### PR TITLE
Add ReadmeGenAI to Documentation Generation (#205)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Tools that auto-generate documentation, diagrams, and changelogs from source cod
 - [DocuWriter.ai](https://www.docuwriter.ai/) — AI-powered web app to generate automated Code & API documentation from your source code files.
 - [EkLine](https://ekline.io/) — AI-powered documentation tool with quality checks, style guide enforcement, and automatic doc generation.
 - [Changenotes](https://changenotes.app) — AI-powered changelog generator. Connects to GitHub, auto-generates categorized changelogs from commits and PRs on every release. Free tier available, Pro $9/mo.
+- [ReadmeGenAI](https://github.com/BeyteFlow/ReadmeGenAI) — AI-powered README generator for GitHub. Paste a repo URL and instantly create a professional, well-structured README.md file. Open source, TypeScript, with live demo at readmegen-ai.vercel.app.
 
 ---
 


### PR DESCRIPTION
## Description

Closes #205

Adds **ReadmeGenAI** to Documentation Generation. AI-powered README generator for GitHub — paste a repo URL and instantly create a professional, well-structured README.md file. 105+ stars, TypeScript, active development.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries