### PR TITLE
Add OpenRuna AI developer tools directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,3 +441,7 @@ Curated lists, comparison guides, and configuration templates for AI coding tool
 - [AI Coding Guide (中文)](https://github.com/jnMetaCode/ai-coding-guide) — Chinese best practices for 8 AI coding tools (Claude Code, Cursor, Copilot, Windsurf, Gemini CLI, Kiro, Aider, Trae) with copy-paste config templates and multi-tool collaboration workflows.
 - [Claude Code Skills 中文精选集](https://claude-skills.bt199.com/) — Chinese curated directory of Claude Code Skills, agents, plugins, and workflow resources for developers using Claude Code.
 - [Awesome AI Startups — Coding & Developer Tools](https://github.com/nowork-studio/awesome-ai-startups#-coding--developer-tools) — 100+ indie-built AI coding assistants, dev tools, and code-generation products from bootstrapped, pre-seed, and angel-funded startups.
+
+## Directories
+
+- [OpenRuna](https://www.openruna.com/best/ai-coding-prompts) — Graph directory of AI coding prompts, tools, and n8n workflows with typed resource relations.


### PR DESCRIPTION
Adds [OpenRuna](https://www.openruna.com/best/ai-coding-prompts) — graph-linked catalog of AI dev tools, coding prompts, MCP servers, and workflows.

Made with [Cursor](https://cursor.com)