### PR TITLE
Add Skill Hub — 2800+ AI Agent Skills navigator to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ Tools that generate components, mockups, and frontend code from text prompts or 
 
 ### Coding Agents
 
+
+- [Skill Hub](https://skill.442595.xyz/) — 2800+ AI Agent Skills 分类导航站，支持 Claude Code / Cursor / Codex / Hermes 等多平台技能筛选
 Autonomous AI agents that work on existing codebases to fix bugs, refactor code, and create pull requests:
 
 - [Factory](https://www.factory.ai/) — Agent-native software development platform with "Droids" that work across IDE, terminal, CLI, Slack/Teams, and CI/CD. Handles refactors, incident response, and migrations.


### PR DESCRIPTION
## 新增: Skill Hub

**描述**: 2800+ AI Agent Skills 分类导航站
- 2800+ AI Agent Skills & MCP Tools
- Coding Agents 工具技能发现平台
- 支持 Claude Code、Cursor、Codex、Hermes 等多平台筛选
- 在线访问: https://skill.442595.xyz/