### PR TITLE
Add codex-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [models](https://github.com/arimxyer/models) — A TUI for browsing AI models, benchmarks from Artificial Analysis, and coding agents with GitHub integration. Built with Rust and Ratatui.
 - [Jctx](https://github.com/Shashwat-Gupta57/Jctx) — Python CLI that extracts structured, architecture-aware context from Python, Kotlin, and Java codebases for LLMs. Features internal dependency mapping and token estimation.
 - [CCG Workflow](https://github.com/fengshao1227/ccg-workflow) — Multi-model collaboration system for Claude Code. Orchestrates Claude + Codex + Gemini with 28 slash commands, smart routing (Gemini for frontend, Codex for backend), Agent Teams for parallel development, and 6 built-in quality gate skills. One-command install via npx.
+- [codex-fixes](https://github.com/zhuhaow/codex-fixes) — CLI that checks known Codex issues, previews applicable fixes, and applies platform-scoped workarounds.
 - [Butterfish](https://butterfi.sh) — CLI tool that embeds ChatGPT in your shell for easy access. Includes simple agentic capabilities.
 - [TmuxAI](https://tmuxai.dev/) - AI-powered, non-intrusive terminal assistant.
 - [IWE](https://github.com/iwe-org/iwe) — Markdown knowledge graph with CLI that gives AI agents structured access to your knowledge base — no vector database required.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [models](https://github.com/arimxyer/models) — A TUI for browsing AI models, benchmarks from Artificial Analysis, and coding agents with GitHub integration. Built with Rust and Ratatui.
 - [Jctx](https://github.com/Shashwat-Gupta57/Jctx) — Python CLI that extracts structured, architecture-aware context from Python, Kotlin, and Java codebases for LLMs. Features internal dependency mapping and token estimation.
 - [CCG Workflow](https://github.com/fengshao1227/ccg-workflow) — Multi-model collaboration system for Claude Code. Orchestrates Claude + Codex + Gemini with 28 slash commands, smart routing (Gemini for frontend, Codex for backend), Agent Teams for parallel development, and 6 built-in quality gate skills. One-command install via npx.
-- [codex-fixes](https://github.com/zhuhaow/codex-fixes) — CLI that checks known Codex issues, previews applicable fixes, and applies platform-scoped workarounds.
+- [codex-fixes](https://github.com/zhuhaow/codex-fixes) — Checks your local Codex install for known issues and runs the matching community-maintained fix scripts.
 - [Butterfish](https://butterfi.sh) — CLI tool that embeds ChatGPT in your shell for easy access. Includes simple agentic capabilities.
 - [TmuxAI](https://tmuxai.dev/) - AI-powered, non-intrusive terminal assistant.
 - [IWE](https://github.com/iwe-org/iwe) — Markdown knowledge graph with CLI that gives AI agents structured access to your knowledge base — no vector database required.


### PR DESCRIPTION
## Description

Adds codex-fixes to Terminal > CLI Utilities.

codex-fixes checks your local Codex install for known issues and runs the matching community-maintained fix scripts.

## Checklist

- [ ] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
