### PR TITLE
Add ToolNest (FreeAI.tools) — 68+ free browser-based developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Web utilities for quick code generation, language translation, and regex creatio
 - [JSONFix](https://jsonfix-lake.vercel.app/) — AI-powered JSON repair tool that instantly fixes malformed JSON with missing quotes, trailing commas, and syntax errors.
 - [CronAI](https://cronai-nu.vercel.app/) — Converts plain English schedule descriptions into correct cron expressions using AI.
 - [RegexAI](https://regexai-six.vercel.app/) — Generates working regular expressions from plain English descriptions with explanations. Supports multiple regex flavors.
+- [ToolNest (FreeAI.tools)](https://nguyenminhduc9988.github.io/free-tools-hub/) — 68+ free browser-based developer tools: JSON formatter, cron builder, code minifiers, hash generators, Base64, color converters, and more. Zero ads, no login required.
 
 ---
 


### PR DESCRIPTION
## ToolNest (FreeAI.tools)

**URL:** https://nguyenminhduc9988.github.io/free-tools-hub/

**Category:** Snippet & Utility Tools

**Description:** A collection of 68+ free, browser-based developer tools including JSON formatter, cron expression builder, code minifiers, hash generators, Base64 encoder/decoder, color converters, UUID generators, and more. No ads, no login required, all tools work entirely in the browser.

**Why it fits:** The list already includes similar web utilities (CodePal, AI Code Convert, AutoRegex, etc.). ToolNest complements these with a broader set of free developer utilities beyond just AI-powered tools.