### PR TITLE
Add Scalekit to the developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Platforms that scaffold and deploy full-stack applications from natural language
 - [Leap.new](https://leap.new/) — Builds functional apps with real backend services, APIs, and deploys to your cloud.
 - [Pico](https://picoapps.xyz) — End-to-end micro app generator with instant deployment.
 - [SoftGen](https://softgen.ai/) — AI-powered software generation platform for building Web Apps.
+- [Scalekit](https://www.scalekit.com/) - Add 3000+ tools to the AI agent you're building now. 
 - [LlamaCoder](https://llamacoder.together.ai/) — Open source code generation model for building applications using open source LLMs.
 - [Forge](https://forge-web.rebaselabs.online) — AI-powered full-stack app creator that generates Next.js apps from natural language. BYOK model — use your own Anthropic, OpenAI, or Google AI key with no markup. Multi-stage pipeline with auto-fix and TypeScript strict mode.
 - [e2b_Fragments](https://fragments.e2b.dev/) — Platform for building and deploying AI-powered applications with sandboxed environments.


### PR DESCRIPTION
This PR proposes to add Scalekit to the list.

## Description

Developers building AI agents often struggle to handle auth and want to add tools from different connectors to best resolve or solve for their users. Scalekit orchestrates this problem for developers building AI agents.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
