### PR TITLE
Add Quota Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard) — Local-only, privacy-first dashboard for tracking AI subscription quota across Claude Code Max, Kimi, and Z.ai. ([Demo](https://ryan-knowone.github.io/quota-dashboard/?mock=1))
 
 ---
 


### PR DESCRIPTION
## Description

Adds [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard) — a local-only, privacy-first dashboard for tracking AI subscription quota across Claude Code Max, Kimi, and Z.ai. Runs entirely in the browser; tokens never leave the user's machine.

Live demo with mock data (no credentials required): https://ryan-knowone.github.io/quota-dashboard/?mock=1

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries