### PR TITLE
Add GENZ TECH AI Coding Leaderboard to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Curated lists, comparison guides, and configuration templates for AI coding tool
 - [aiforcode.io](https://aiforcode.io) — Expert-curated directory of 42+ AI coding tools with transparent 100-point scoring, head-to-head comparisons, and an interactive tool recommendation quiz. Verified monthly.
 - [Awesome Code Docs](https://github.com/johnxie/awesome-code-docs) — Curated deep-dive tutorials for open-source AI and developer tooling projects.
 - [AI Coding Compare](https://aicodingcompare.com) — Compare 50+ AI coding assistants with features, pricing, and performance benchmarks.
+- [GENZ TECH AI Coding Leaderboard](https://genztech.blog/ai-coding-leaderboard/) — Live ranking of AI coding models by confirmed SWE-bench Verified/Pro scores and price; only figures verified against primary sources are shown, with public JSON/CSV and an embeddable widget.
 - [ClaudeDown](https://claudedown.com) - Real-time Claude AI complaint tracker and outage detector using Twitter/X sentiment data.
 - [Havoptic](https://havoptic.com/) — Free, open-source timeline tracking releases from AI coding tools. Auto-updated daily.
 - [AI Coding Guide (中文)](https://github.com/jnMetaCode/ai-coding-guide) — Chinese best practices for 8 AI coding tools (Claude Code, Cursor, Copilot, Windsurf, Gemini CLI, Kiro, Aider, Trae) with copy-paste config templates and multi-tool collaboration workflows.


### PR DESCRIPTION
Adds the GENZ TECH AI Coding Leaderboard under **Resources**, alongside AI Coding Compare and the other comparison/benchmark resources.

It's a live ranking of AI coding models by **confirmed** SWE-bench Verified/Pro scores plus price. The distinguishing rule: a score (or price) only appears once it's confirmed against the model maker's primary source, an independent eval (vals.ai / llm-stats), or the official SWE-bench leaderboard; anything unconfirmed is marked "verifying" and shown without a number rather than estimated. It covers open + closed models, is updated as models ship, and offers public JSON/CSV plus an embeddable widget.