### PR TITLE
Add Vaaya to Agent Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [Vaaya](https://vaaya.ai) — Lets AI coding agents call and pay for external paid APIs and sandboxes per-call with no API keys, via one MCP server (`npx -y @vaaya/mcp` or remote `https://vaaya.ai/mcp`). Covers code sandboxes, browser automation, web search and scraping, media generation, research, and email; pays over x402 (USDC on Base) or Stripe. Anonymous `tools/list`, OAuth 2.1.
 
 ---
 


### PR DESCRIPTION
Adds Vaaya to ## Agent Infrastructure. Vaaya lets AI coding agents call and pay for external paid APIs and sandboxes per-call, via one MCP server (npx -y @vaaya/mcp or https://vaaya.ai/mcp) with no API keys — code sandboxes, browser automation, scraping, research, media, email; pays over x402 or Stripe. Uses AI, developer-focused, MCP-native, matches the section's bullet style. Read PULL_REQUEST_TEMPLATE.md; appended to the end of the section. Site: https://vaaya.ai · Docs: https://vaaya.ai/llms.txt