### PR TITLE
Add CodeAlmanac

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [CodeAlmanac](https://github.com/AlmanacCode/codealmanac) — Almanac turns your past agent conversations into a connected Markdown wiki that lives inside your repo. Agents automatically query this wiki while they code, pulling in prior context, decisions, and implementation details. The wiki updates as your conversations and codebase evolve, so your agents keep working from the latest project context.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adds CodeAlmanac to the Codebase Intelligence section.

Almanac turns your past agent conversations into a connected Markdown wiki that lives inside your repo. Agents automatically query this wiki while they code, pulling in prior context, decisions, and implementation details. The wiki updates as your conversations and codebase evolve, so your agents keep working from the latest project context.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
