### PR TITLE
Add Independent Review Toolkit to PR & Code Review Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ Integrations that automatically review pull requests and suggest code fixes:
 - [prpack-action](https://github.com/Lucas2944/prpack-action) — GitHub Action that runs prpack on every PR, uploads the packed markdown as an artifact, and posts a summary comment. MIT.
 - [Issue AI Agent](https://github.com/alexyan0431/issue-ai-agent) — Open source GitHub Action that auto-classifies, labels, and replies to issues using AI. Detects duplicates and handles follow-up comments. Supports Claude, OpenAI, and OpenAI-compatible APIs (BYOK). MIT licensed.
 
+- [Independent Review Toolkit](https://github.com/redamancy231-create/independent-review-toolkit) — Multi-model independent code review toolkit with SOP templates, adversarial challenge framework, and prompts validated across 5 LLM backends. CC BY 4.0.
+
 ### CI/CD & Testing Automation
 
 Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:


### PR DESCRIPTION
## Description

Adds [Independent Review Toolkit](https://github.com/redamancy231-create/independent-review-toolkit) to the PR & Code Review Bots section. It is a multi-model independent code review toolkit that uses multiple LLM backends to review code and reduce single-model bias. Includes SOP templates, adversarial challenge framework, and prompts validated through 50+ rounds across 5 LLM backends. Placed at end of section, single entry, follows existing list format. URL verified.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries