### PR TITLE
Add BBARIT to AI-Native IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Full development environments with AI for code generation, chat, and debugging:
 - [GitWit](https://gitwit.dev/) — Web-based editor for building ReactJS applications with AI.
 - [OneCompiler](https://onecompiler.com/) — A free AI Powered online compiler supporting over 70 languages, including Java, Python, MySQL, C++, and HTML, for writing, running, and sharing code.
 - [BuilderStudio](https://builderstudio.dev) - Native macOS agentic coding workspace from WunderCorp for secure local/cloud AI development, reusable Skills and Pathways, MCP integrations, Hermes-powered container-only execution, Agentic Swarms for parallel specialized agents, app previews, terminal workflows, packaging/deployment, and flexible routing across 380+ AI models.
+- [BBARIT](https://github.com/bbarit/terminal) — Native all-in-one AI coding IDE (Tauri/Rust) with multi-agent terminals, office document editing, and an embedded browser the agent can drive. Bring any model — Claude, GPT, Gemini, Kimi, DeepSeek — or run locally with Ollama; free with a GitHub sign-in.
 
 ### IDE Extensions
 


### PR DESCRIPTION
## Description

Adds **BBARIT** to AI-Native IDEs — a native (Tauri/Rust, not Electron) all-in-one AI coding IDE for macOS (Apple Silicon) and Windows, built around a coding agent: multi-agent PTY terminals across projects, office document editing, and an embedded browser the agent can drive. BYO model keys (Claude, GPT, Gemini, Kimi, DeepSeek) or fully local via Ollama. Free with a GitHub sign-in. 2-min demo: https://youtu.be/PFPHs3V8sPM

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries