### PR TITLE
Add CocoIndex Code to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [CocoIndex Code](https://github.com/cocoindex-io/cocoindex-code) — AST/tree-sitter code search engine and MCP server that indexes a codebase and returns compact, relevant snippets so coding agents retrieve just what they need and use less context. Open-source, runs locally, Python.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adds [CocoIndex Code](https://github.com/cocoindex-io/cocoindex-code) to **Terminal → Codebase Intelligence**.

It's an open-source (Apache-2.0) AST / tree-sitter code search engine and MCP server. It indexes a codebase and returns compact, relevant snippets so AI coding agents retrieve just what they need instead of loading whole files, reducing context/token usage. Runs locally, Python, ~2.5k GitHub stars. Sits alongside Reflex, SeaGOAT, and sourcebook. Disclosure: I'm a maintainer.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)