### PR TITLE
Add autobatcher to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [autobatcher](https://github.com/doublewordai/autobatcher) — Drop-in AsyncOpenAI replacement that transparently batches requests through the Batch API to cut inference costs by up to 90%. Python and TypeScript, works with any OpenAI-compatible endpoint. MIT.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **autobatcher** (`doublewordai/autobatcher`) to the **Usage Analytics & Cost Tracking** section.

autobatcher is an open-source (MIT) drop-in `AsyncOpenAI` replacement that transparently batches requests through the OpenAI-compatible Batch API to cut inference costs by up to 90%. It works with any OpenAI-compatible endpoint and ships for both Python and TypeScript, so developers can reduce their AI API spend without changing application code.

Single entry, inserted at the end of the section to match neighbor formatting.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
