### PR TITLE
Add LLMGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Platforms that scaffold and deploy full-stack applications from natural language
 - [Blank Space](https://www.blankspace.build/) — Open-source AI app builder for creating web applications using natural language. Self-hostable alternative to v0, Lovable, and Bolt.
 - [Fastshot](https://fastshot.ai/) — AI driven no-code platform for building and deploying mobile apps.
 - [ai-vertical-saas-gen](https://github.com/kurtnebiev-elvis4/ai-vertical-saas-gen) — CLI that generates complete vertical SaaS apps (Next.js 14 + Supabase) with industry-specific data models for 20+ niches. Zero dependencies, offline, outputs 20 deployable files in one command.
+- [LLMGraph](https://llmgraph.ai) — Visual builder developers use to build and ship LLM-backed APIs. Chain models, RAG, and tools on a canvas; each workflow deploys as a REST API endpoint plus an embeddable chat widget.
 
 ### UI Generators
 


### PR DESCRIPTION
## Description

Adds **LLMGraph** to **Web-Based Tools > App Builders**.

LLMGraph is a developer tool for building LLM-backed APIs: a visual, graph-based builder where developers chain models, RAG, and tool calls on a canvas, then deploy each workflow as a live REST API endpoint (plus an embeddable chat widget). The output is an API developers integrate into their own applications.

For transparency: it is a commercial SaaS (14-day trial on every tier), not open source.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)