### PR TITLE
Add usage-guard to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [usage-guard](https://github.com/eltonylfgi-blip/claude-code-usage-guard) - Claude Code plugin that warns you in-session *before* you hit your 5-hour or weekly quota, using a `Stop` hook that interrupts instead of waiting for you to glance at a status line. Shows an even-pace readout (whether you're ahead of or behind an even split of the week, so you know to slow down or push), exact % used with a reset countdown, a weighted burn-rate fallback when the real quota isn't exposed, and a `/usage-guard:usage` command on demand. Zero dependencies, local-only, no network calls. MIT.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **usage-guard** to the *Usage Analytics & Cost Tracking* section. It is an open-source (MIT) Claude Code plugin that warns you in-session, before you hit your 5-hour or weekly quota, via a `Stop` hook that interrupts instead of waiting for you to glance at a status line. It shows an even-pace readout (ahead of or behind an even split of the week), exact % used with a reset countdown, a weighted burn-rate fallback, and a `/usage-guard:usage` command. Zero dependencies, local-only, no network calls.

It sits alongside the existing quota and pace trackers already in that section (claude-lens, onWatch, WhereMyTokens); the differentiator is that it is a proactive in-session guard rather than a passive display. One-line addition, appended to the section like the neighbouring entries.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries