### PR TITLE
docs: add construct to CLI utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [gptcomet](https://github.com/belingud/gptcomet) — CLI tool to help you generate commit message and review changes. Supports multiple providers and languages.
 - [Baz CLI](https://github.com/baz-scm/baz-cli) - CLI for AI assisted code review, with access to the actual code, diff etc.
 - [models](https://github.com/arimxyer/models) — A TUI for browsing AI models, benchmarks from Artificial Analysis, and coding agents with GitHub integration. Built with Rust and Ratatui.
+- [construct](https://github.com/construct-worlds/construct) — Terminal-native agentic development environment. Managing multiple coding agent sessions (Codex, Claude Code, Grok, and more) with fork/merge, agent-to-agent orchestration. Single rust binary.
 - [Jctx](https://github.com/Shashwat-Gupta57/Jctx) — Python CLI that extracts structured, architecture-aware context from Python, Kotlin, and Java codebases for LLMs. Features internal dependency mapping and token estimation.
 - [CCG Workflow](https://github.com/fengshao1227/ccg-workflow) — Multi-model collaboration system for Claude Code. Orchestrates Claude + Codex + Gemini with 28 slash commands, smart routing (Gemini for frontend, Codex for backend), Agent Teams for parallel development, and 6 built-in quality gate skills. One-command install via npx.
 - [Butterfish](https://butterfi.sh) — CLI tool that embeds ChatGPT in your shell for easy access. Includes simple agentic capabilities.


### PR DESCRIPTION
## Description

Adds [construct](https://github.com/construct-worlds/construct) to the **CLI Utilities** section.

construct is a terminal-native TUI for managing multiple coding agent sessions (Codex, Claude Code, Grok, and more) with fork/merge, MCP orchestration, and ACP agent server support via `construct acp`.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries