### PR TITLE
Add VibeKit.bot to App Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Platforms that scaffold and deploy full-stack applications from natural language
 - [Blank Space](https://www.blankspace.build/) — Open-source AI app builder for creating web applications using natural language. Self-hostable alternative to v0, Lovable, and Bolt.
 - [Fastshot](https://fastshot.ai/) — AI driven no-code platform for building and deploying mobile apps.
 - [ai-vertical-saas-gen](https://github.com/kurtnebiev-elvis4/ai-vertical-saas-gen) — CLI that generates complete vertical SaaS apps (Next.js 14 + Supabase) with industry-specific data models for 20+ niches. Zero dependencies, offline, outputs 20 deployable files in one command.
+- [VibeKit.bot](https://vibekit.bot) — AI app builder that runs from your phone: every app gets its own hosted coding agent that builds, deploys to a live subdomain, and keeps improving the app through chat, with GitHub sync. BYOK (Anthropic/OpenAI) or pay-as-you-go, plus a native iOS app.
 
 ### UI Generators
 


### PR DESCRIPTION
## Description

Adds [VibeKit.bot](https://vibekit.bot) to the **App Builders** section (end of section, format-matched: name link + one-line description).

VibeKit.bot is a phone-first AI app builder: each app gets its own persistent hosted coding agent that builds the app, deploys it to a live subdomain, and keeps improving it through chat, with GitHub sync. Works BYOK (Anthropic/OpenAI keys, billed direct with no markup) or pay-as-you-go, and has a native iOS app.

Note: this is vibekit.bot, unrelated to the discontinued `superagent-ai/vibekit` SDK that shares the name — hence listing as "VibeKit.bot".

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
