### PR TITLE
Add Crucible to CI/CD & Testing Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [Fine](https://fine.dev/?ref=awesome) — AI Dev Environment for automating mundane work. Integrate GitHub, Sentry, Linear. Get context-aware answers to questions. Plan, design and implement changes. Automate self-healing CI/CD.
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
+- [Crucible](https://github.com/Jott2121/crucible) — Measures whether AI-written tests actually catch bugs: injects real defects and reports how many the suite misses. Runs as a GitHub Action; the diagnose needs no model or API key. Open source.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
 
 ---


### PR DESCRIPTION
Adds [Crucible](https://github.com/Jott2121/crucible) to **CI/CD & Testing Automation**, right after Recurse ML (closest neighbour — that one finds bugs in AI-generated code; this one finds bugs in AI-generated *tests*).

**The problem it addresses:** coverage measures what your tests *ran*, not what they would *catch*. That gap widens when a model writes both the code and its tests, because models happily produce tests that execute code without asserting the thing that breaks. On a real module with 7 passing tests and 97% line coverage, **25 of 71 injected defects survived**.

**What it does:** injects real defects (mutation testing), reports how many the suite misses, and names the survivors. Optionally an adversarial loop then writes tests to kill exactly those, with mechanical verdicts — pytest kills the mutant or it doesn't, so no model grades model output.

- Open source (MIT), Python + pytest
- Ships as a GitHub Action that comments the mutation score on every PR and can fail the build below a floor
- The diagnose calls **no model** and needs **no API key**
- Dogfooded: runs its own mutation gate on itself (982 mutants, 977 killed, 5 documented survivors)

Happy to trim the description if it runs long for the list's style.