### PR TITLE
Add Crucible to CI/CD & Testing Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [Fine](https://fine.dev/?ref=awesome) — AI Dev Environment for automating mundane work. Integrate GitHub, Sentry, Linear. Get context-aware answers to questions. Plan, design and implement changes. Automate self-healing CI/CD.
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
+- [Crucible](https://github.com/Jott2121/crucible) — Measures whether AI-written tests actually catch bugs: injects real defects and reports how many the suite misses. Runs as a GitHub Action; the diagnose needs no model or API key. Open source.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
 
 ---


### PR DESCRIPTION
## Description

Adds [Crucible](https://github.com/Jott2121/crucible) to **CI/CD & Testing Automation**, immediately after Recurse ML (its closest neighbour: that tool finds bugs in AI-generated code, this one finds bugs in AI-generated *tests*).

Coverage measures what your tests *ran*, not what they would *catch*, and that gap widens when a model writes both the code and its tests. Crucible injects real defects into a module and reports how many the suite actually kills. On a real module with 7 passing tests and 97% line coverage, **25 of 71 injected defects survived**.

It uses AI in an adversarial loop: a Tester agent writes tests, mutation testing names the surviving defects, and a Critic agent writes tests to kill exactly those. Verdicts stay mechanical (pytest kills the mutant or it doesn't), so no model grades model output. It ships as a GitHub Action that comments the mutation score on every PR and can fail the build below a floor. Open source (MIT), Python + pytest.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries