### PR TITLE
Add Ditto to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [Ditto](https://github.com/ohad6k/ditto) — Mines your local AI coding session logs (Claude Code, Codex, Copilot CLI, OpenCode) into a personal working profile your agent loads before every task. Single stdlib-only Python file, runs locally. Installs as an Agent Skill via `npx skills add ohad6k/ditto`. MIT.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds Ditto (https://github.com/ohad6k/ditto), an MIT-licensed open-source tool that mines local AI coding session logs (Claude Code, Codex, Copilot CLI, OpenCode) into a personal working profile the agent loads before every task. It is a single stdlib-only Python file that runs locally and installs as an Agent Skill. It fits Configuration & Context Management alongside the other tools that generate and manage agent context files.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries