### PR TITLE
Add OpenAgentRelay to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) — Open-source CLI that exposes a restricted local coding-agent command to teammates or other agents over a trusted LAN, with keyed access, target verification, structured JSON output, and scriptable exit codes.
 
 ---
 


### PR DESCRIPTION
## Description\n\nAdds OpenAgentRelay to CLI Utilities. It is an open-source developer tool that invokes an existing local coding-agent command behind a restricted trusted-LAN relay, so teammates or other agents can call it through a scriptable CLI without moving the publisher's source, prompts, dependencies, or credentials.\n\n## Checklist\n\n- [x] The entry is a tool that uses AI\n- [x] The entry is a developer-focused tool\n- [x] The description is unambiguous and clear\n- [x] The description matches the style of other entries