### PR TITLE
Add UIZZE to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [UIZZE](https://uizze.com) — Codex-first UI reference and verification service that gives coding agents real web and iOS examples, creates design contracts, validates implementation manifests, and critiques rendered interfaces through hosted MCP.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds UIZZE to Configuration & Context Management. UIZZE gives coding agents concrete UI reference context before implementation, then provides product-specific design contracts, implementation validation, audits, and rendered-interface critique through a hosted MCP workflow.

- Canonical repository: https://github.com/uizze/uizze
- Free Skill install: `npx skills add https://uizze.com --skill anti-ui-slop`
- Evidence base: 800,000+ real web and iOS screens

I build UIZZE, so this is a disclosed first-party submission.