### PR TITLE
Add Loupe (open-source local AI website builder, built on the Claude Agent SDK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
 - [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
+- [Loupe](https://github.com/winchxyz/loupe) — Open-source, local AI website builder and web-design studio for Windows, built on the Claude Agent SDK. AI agents build real websites, you refine them Figma-grade directly on the live render, and every visual edit is verified against the real browser render. BYOK (Anthropic, OpenAI, Gemini, xAI, OpenRouter) or existing Claude Code / Codex / Grok / Copilot subscription CLIs. Electron, MIT.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **Loupe** (https://github.com/winchxyz/loupe) to **Desktop & Mobile Applications**. Loupe is an open-source (MIT), local Windows desktop app (Electron, built on the Claude Agent SDK) where AI agents build real websites and the user refines them Figma-grade directly on the live render — every visual edit is verified against the real browser render. It runs BYOK on the user's own API keys (Anthropic/OpenAI/Gemini/xAI/OpenRouter) or their existing Claude Code / Codex / Grok / Copilot subscription CLIs; actively maintained, currently v0.1.1. The entry is one line, appended to the end of the section, matching the surrounding em-dash format.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)