### PR TITLE
Add TokenTracker to usage analytics and cost tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [TokenTracker](https://github.com/mm7894215/TokenTracker) — Local-first token usage and cost dashboard for 27 AI coding tools, including Claude Code, Codex, Cursor, Gemini CLI, and Copilot. Includes a CLI, native macOS and Windows apps, 4 desktop widgets, achievements, and an optional desktop pet. Reads local usage logs without reading prompts or message content. MIT.
 
 ---
 


### PR DESCRIPTION
## Description

Adds TokenTracker to the existing Usage Analytics & Cost Tracking section. TokenTracker is a local-first dashboard and CLI for tracking token usage and cost across 27 AI coding tools, with native macOS and Windows apps.

## Checklist

- [ ] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

TokenTracker analyzes the local usage logs produced by AI coding tools rather than invoking an AI model itself. I left the first item unchecked to be precise; it matches this section alongside the other AI-usage analytics tools.