### PR TITLE
Add ctx-optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [ctx-optimize](https://github.com/muthuishere/ctx-optimize) — Deterministic code knowledge graph as a single static Go binary. Indexes a repo with tree-sitter into a local graph a coding agent queries — symbol lookup, callers and callees, and change impact — instead of grep-and-read. No LLM at query time, no database, works offline. MIT.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adds ctx-optimize under Codebase Intelligence. It is a deterministic code knowledge-graph CLI (one static Go binary) that indexes a repo with tree-sitter so a coding agent can query symbols, callers, callees, and change impact instead of grep-and-read, with no LLM at query time. It fits the section alongside entries like sourcebook and Reflex.

Repo: https://github.com/muthuishere/ctx-optimize

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries