### PR TITLE
Add ContextPruner tool to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,6 @@ Secure isolated environments for running AI coding agents with controlled access
 
 Tools that manage and sync AI agent configurations, rules, and context across editors:
 
-- [Context7](https://context7.com/) — Documentation platform that provides up-to-date, version-specific documentation and code examples for any library directly into Cursor, Claude Code, Windsurf, and other AI coding tools.
 - [ctxlint](https://github.com/YawLabs/ctxlint) — Open-source linter for AI context files (CLAUDE.md, .cursorrules, copilot-instructions.md) that catches stale paths, wrong commands, and token waste by validating against the real codebase.
 - [Entroly](https://github.com/juyterman1000/entroly) - Open-source context optimization engine that cuts AI token costs by 70-95%. Uses submodular knapsack selection and PRISM reinforcement learning to provide the exact context needed to 65+ supported AI coding agents. Features a built-in MCP server, semantic caching, and SimHash deduplication. Apache-2.0.
 - [lean-ctx](https://leanctx.com) — Open-source context runtime for AI coding agents. MCP server (optional shell hook) that compresses file reads, shell output, and codebase search to reduce token usage, often 60–99% on supported workflows. 46 tools, session caching, AST-aware compression for 18 languages, 90+ shell patterns. Apache-2.0.
@@ -385,6 +384,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [ContextPruner](https://contextpruner.app) — Generates AGENTS.md, CLAUDE.md, GEMINI.md, Cursor rules, and Copilot instructions from your file tree, telling coding agents which files to skip (lockfiles, build output, vendored deps) to keep context lean. Free, runs in the browser.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
Adds ContextPruner under Agent Infrastructure → Configuration & Context Management.

It's a free, browser-based tool that generates agent config files (AGENTS.md,
CLAUDE.md, GEMINI.md, .cursor/rules, Copilot instructions) from a repo's file
tree, marking which files agents should skip so they don't spend context on
lockfiles, build output, and vendored dependencies.

- AI-workflow / developer-focused: yes (agent context tooling)
- Description matches the style of neighboring entries
- Disclosure: I'm the maker of ContextPruner.
