### PR TITLE
Add Tura local coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
-- [Tura](https://github.com/Tura-AI/tura) — Local open-source coding agent with CLI, TUI, and GUI interfaces. Edits repositories, executes commands, verifies changes, manages task-scoped context, and publishes reproducible long-horizon benchmarks.
+- [Tura](https://github.com/Tura-AI/tura) — Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.
 
 ### CLI Utilities
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
+- [Tura](https://github.com/Tura-AI/tura) — Local open-source coding agent with CLI, TUI, and GUI interfaces. Edits repositories, executes commands, verifies changes, manages task-scoped context, and publishes reproducible long-horizon benchmarks.
 
 ### CLI Utilities
 


### PR DESCRIPTION
## Description

Adds Tura to Terminal Agents.

**Tura: 16.7% better performance, 77.5% fewer rounds.**

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.

Tura is an AI-powered, developer-focused tool with CLI, TUI, and GUI interfaces. It edits repositories, executes commands, verifies changes, and manages task-scoped context.

Repository: https://github.com/Tura-AI/tura  
Benchmark: https://turaai.net/benchmark

Disclosure: I am affiliated with the Tura project. This submission was prepared with AI assistance.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries