### PR TITLE
Add Alpheon to Git & Commit Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Tools that generate commit messages and PR descriptions from diffs:
 - [git-lrc](https://github.com/HexmosTech/git-lrc) - Free, unlimited AI code reviews that run on every commit.
 - [GitBrain](https://gitbrain.dev/) — Git client that splits changes and generates commit messages using OpenAI.
 - [GitButler](https://gitbutler.com/) — Git client for simultaneous branches on top of your existing workflow. Defaults to OpenAI, can be changed to Perplexity for generating conventional commit messages.
+- [Alpheon](https://github.com/BravoAlphaSix/alpheon) — Dependency-free CLI that turns your git diff into a reviewable "handoff note" (what changed, why, what was tried and rejected, what's next) saved as `HANDOFF.md` in your repo, preserving the reasoning behind changes across AI coding sessions and tools. Free tier is a template generator; AI-drafted notes are on the roadmap. MIT.
 
 ### Documentation Generation
 


### PR DESCRIPTION
Adds Alpheon under Git & Commit Helpers.

Checklist:
- [x] The entry is a tool used in AI coding workflows (it preserves the reasoning behind code changes across AI sessions and tools)
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

Note: I've described it honestly. The current free tier is a template generator (structures the note, fills in git data); AI-drafted 'why' notes are on the roadmap. Happy to adjust the placement or wording if you'd prefer it elsewhere.