### PR TITLE
Add SourceryKit to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [SourceryKit](https://github.com/ProvablyAI/sourcerykit) — Python SDK that verifies an AI agent's outbound calls and MCP handoffs against a source of truth, then blocks anything not on the trusted-endpoint allow-list. Logs every call and constrains what a compromised agent can reach at the network boundary.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds SourceryKit to the Configuration & Context Management section, alongside the other agent guardrail tools (Zenable, pi-steering-hooks).

It's a Python SDK that verifies an AI agent's outbound calls and MCP handoffs against a source of truth, so a call only goes out if the agent's claims check out. It logs each call and blocks anything not on the trusted-endpoint allow-list.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries