### PR TITLE
Add Draftmark (Agent Infrastructure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [Draftmark](https://draftmark.app) — Self-hostable markdown collaboration surface for human + agent review loops. Agents publish docs via REST API/CLI, humans or other agents leave inline comments, reactions, and reviews, and agents pull the structured feedback back to revise. `author_type: agent` badges and a `.draftmark.json` convention for agent workflows. MIT.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
Adds **Draftmark** under Agent Infrastructure → Configuration & Context Management, alongside the other agent-accessible knowledge/context surfaces.

[Draftmark](https://draftmark.app) is a self-hostable markdown collaboration surface built for human + agent review loops: agents publish docs via REST API/CLI, humans or other agents leave inline comments, reactions, and reviews, and agents pull the structured feedback back to revise. It ships `author_type: agent` badges, a `.draftmark.json` convention, and a `draftmark` CLI for agent workflows.

- Source: https://github.com/draftmark-app/draftmark (MIT)
- API docs: https://draftmark.app/api-docs

Happy to move it to a different subsection if you feel another placement fits better.