### PR TITLE
Add DocFlow to Documentation Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ Tools that auto-generate documentation, diagrams, and changelogs from source cod
 - [DocuWriter.ai](https://www.docuwriter.ai/) — AI-powered web app to generate automated Code & API documentation from your source code files.
 - [EkLine](https://ekline.io/) — AI-powered documentation tool with quality checks, style guide enforcement, and automatic doc generation.
 - [Changenotes](https://changenotes.app) — AI-powered changelog generator. Connects to GitHub, auto-generates categorized changelogs from commits and PRs on every release. Free tier available, Pro $9/mo.
+- [DocFlow](https://aicodedocumentationgenerator.com) — GitHub App that auto-generates README, CHANGELOG, and API docs on every merged PR. AST + LLM hybrid for accurate function signatures; free for public repos.
 
 ---
 


### PR DESCRIPTION
DocFlow is a GitHub App that fits the Documentation Generation section alongside DocuPilot, DocuWriter.ai, EkLine, and Changenotes.

- **Website:** https://aicodedocumentationgenerator.com
- **What it does:** Automatically generates README, CHANGELOG, and API documentation on every merged PR, using an AST + LLM hybrid pipeline for accurate function signatures.
- **Pricing:** Free for public repos; Pro plan for private repos.

Thanks for maintaining this list!