### PR TITLE
Add Session Watcher to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [Session Watcher](https://github.com/nomadop/session-watcher) — EOQ-based context economics for coding agents. Real-time dashboard and terminal statusline that signal optimal session restart timing by treating LLM prompt cache as inventory. Local-first, zero context pollution.
 
 ---
 


### PR DESCRIPTION
## Description

Add [Session Watcher](https://github.com/nomadop/session-watcher) to Usage Analytics & Cost Tracking.

Session Watcher applies EOQ (Economic Order Quantity) inventory theory to LLM session context — monitoring token cache as inventory and signaling optimal restart timing via a real-time dashboard and terminal statusline. Fully local, zero context pollution.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
