### PR TITLE
Add VibePod to Sandboxing & Isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Secure isolated environments for running AI coding agents with controlled access
 - [FlyDex](https://flydex.net) — Browser-first remote control plane for local Codex sessions with QR pairing, approvals, and machine continuity.
 - [mirrord](https://github.com/metalbear-co/mirrord) — Per-agent isolation inside a shared Kubernetes cluster: traffic filters, DB branches, and Kafka queue splits via the mirrord Operator. Six [Claude Code skills](https://github.com/metalbear-co/skills) cover quickstart, config, operator setup, CI, DB branching, and Kafka splitting; install via `/plugin marketplace add metalbear-co/skills`.
 - [AgentTier](https://github.com/agenttier/agenttier) — Open-source, Kubernetes-native sandbox runtime for AI coding agents (Claude Code, LangGraph, OpenHands). Each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation; runs in interactive `mode: code` (browser terminal) or `mode: agent` (REST `/configure` + SSE-streaming `/invoke`). Apache-2.0.
+- [VibePod](https://github.com/VibePod/vibepod-cli) — Unified CLI for running Claude Code, Codex, OpenCode, Pi, and other AI coding agents in isolated Docker or Podman containers, with persistent configuration and local analytics.
 
 ### Configuration & Context Management
 


### PR DESCRIPTION
## Description

VibePod is an open-source developer tool that provides a unified CLI for running AI coding agents—including Claude Code, Codex, OpenCode, and Pi—in isolated Docker or Podman containers. It also supports persistent configuration and local analytics.

## Checklist

- [X] The entry is a tool that uses AI
- [X] The entry is a developer-focused tool
- [X] The description is unambiguous and clear
- [X] The description matches the style of other entries
