### PR TITLE
Add Find MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [Find MCP](https://github.com/agentage/find-mcp) — MCP server that lets AI coding agents discover other MCP servers. Searches the agentage MCP Catalog (17,000+ servers synced from the official MCP registry) via remote Streamable HTTP (`catalog.agentage.io/mcp`, no auth for search) or stdio (`npx -y @agentage/find-mcp`).
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds Find MCP to "Agent Infrastructure" > "Configuration & Context Management" (alongside Context7), one line matching the section's existing style.

Find MCP is an MCP server for discovering other MCP servers. It searches the agentage MCP Catalog - 17,000+ servers synced from the official MCP registry (registry.modelcontextprotocol.io) - via remote Streamable HTTP (`catalog.agentage.io/mcp`, no auth needed for search) or stdio (`npx -y @agentage/find-mcp`).

- GitHub: https://github.com/agentage/find-mcp
- npm: `@agentage/find-mcp`
- Web UI: https://catalog.agentage.io/mcp

Disclosure: I maintain Find MCP.

## Checklist

- [x] The entry is a tool that uses AI - it's MCP infrastructure for AI coding agents (same class as Context7 in this section): it lets an agent's MCP client discover and connect to other MCP servers.
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
