### PR TITLE
Add constitution-lint-action to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Secure isolated environments for running AI coding agents with controlled access
 
 Tools that manage and sync AI agent configurations, rules, and context across editors:
 
+- [constitution-lint-action](https://github.com/joeyycli/constitution-lint-action) — GitHub Action (and pre-commit hook) that lints CLAUDE.md-style agent constitution files for missing operational guardrails — authority order, injection-defense, spend limits, escalation path, secrets handling — so a gap is caught in CI instead of at 3am by an unattended agent. Zero dependencies, single stdlib-only Python script.
 - [Context7](https://context7.com/) — Documentation platform that provides up-to-date, version-specific documentation and code examples for any library directly into Cursor, Claude Code, Windsurf, and other AI coding tools.
 - [ctxlint](https://github.com/YawLabs/ctxlint) — Open-source linter for AI context files (CLAUDE.md, .cursorrules, copilot-instructions.md) that catches stale paths, wrong commands, and token waste by validating against the real codebase.
 - [Entroly](https://github.com/juyterman1000/entroly) - Open-source context optimization engine that cuts AI token costs by 70-95%. Uses submodular knapsack selection and PRISM reinforcement learning to provide the exact context needed to 65+ supported AI coding agents. Features a built-in MCP server, semantic caching, and SimHash deduplication. Apache-2.0.


### PR DESCRIPTION
## Description

Adds `constitution-lint-action` to **Configuration & Context Management**, alongside ctxlint.

[constitution-lint-action](https://github.com/joeyycli/constitution-lint-action) is a GitHub Action (and pre-commit hook) that lints `CLAUDE.md`-style agent constitution/rules files for missing operational guardrails: authority order, injection-defense, spend limits, escalation path, secrets handling, ledger discipline, self-modification guard, and whether state files it references actually exist. Its niche is validating the structure/completeness of the constitution file itself (the meta-rules an autonomous agent runs under), which is distinct from ctxlint (validates CLAUDE.md/.cursorrules content against the real codebase) — no overlap.

Zero dependencies (single stdlib-only Python script), works as a GitHub Action or a pre-commit hook, exit code 0/1 for CI use.

## Checklist

- [x] The entry is a tool that uses AI — lints the rules file that governs an autonomous AI agent's behavior
- [x] The entry is a developer-focused tool — a CI/pre-commit linter
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
