### PR TITLE
Add Terminal Candy to Terminal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Micro Agent](https://www.builder.io/blog/micro-agent) — An AI agent that writes and fixes code for you.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
+- [Terminal Candy](https://terminalcandy.com/) — A skinnable native macOS terminal for running AI coding agents. Composites a live terminal behind any image via a built-in Skin Builder, with Dock-bounce/sound alerts when Claude Code, Codex CLI, or Gemini CLI finishes or needs input.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
 
 ### CLI Utilities


### PR DESCRIPTION
Adds **[Terminal Candy](https://terminalcandy.com)** to the Terminal Agents section, alongside the existing terminal-for-agents entry (cmux).

It's a native macOS (Swift/AppKit + SwiftTerm) terminal built for running AI coding agents: agent alerts fire a Dock bounce, sound, or bring-to-front when Claude Code, Codex CLI, or Gemini CLI finishes or stops for input, and the whole terminal is reskinnable — any image becomes a working terminal via the built-in Skin Builder. Free 14-day trial, $10 one-time.

Disclosure: I'm the developer.