### PR TITLE
Add Darkmoon (autonomous pentest, AD + Kubernetes + web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Full development environments with AI for code generation, chat, and debugging:
 - [Cursor](https://www.cursor.com/) — An IDE with chat, edit, generate and debug features. Forked from VSCodium, so the interface is similar to VS Code. Uses OpenAI.
 - [Windsurf](https://windsurf.com) — An IDE with chat, edit, generate and debug features. Forked from VSCodium, so the interface is similar to VS Code. Formerly known as Codeium.
 - [Zed](https://zed.dev/) — A high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Autonomous AI pentesting platform (GPL-3.0) covering web, AD and Kubernetes, where the LLM never sees real IPs or credentials (local privacy gateway).
 - [Replit](https://replit.com/) — Web-based IDE with cloud developer environments, code completion, chat, a software development agent and deployments.
 - [Google Antigravity](https://antigravity.google/) — An agent-first IDE that orchestrates autonomous AI agents to plan, execute, and verify complex coding tasks with deep browser integration.
 - [trae](https://www.trae.ai/) — Adaptive AI IDE with chat and code generation.


### PR DESCRIPTION
Hi, thanks for maintaining this list. Adding Darkmoon, a GPL-3.0 autonomous penetration testing platform covering Active Directory and Kubernetes alongside web and APIs. Repo: https://github.com/ASCIT31/Dark-Moon

Full disclosure: our project. Happy to adjust or close if not a fit.