### PR TITLE
Add SDKProof (type-checks AI-generated SDK code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [SDKProof](https://sdkproof.dev) — Type-checks how well AI coding agents use your SDK's current API by compiling model-generated code against the real installed package (no LLM judge). Open-source scorecards for Prisma, the Vercel AI SDK, and Zod.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **SDKProof** to the **Automated Workflows → CI/CD & Testing Automation** section.

SDKProof type-checks how well AI coding agents write an SDK's *current* API: it has a model solve real tasks, compiles the generated code against the real installed package (`tsc --noEmit`), and scores a clean compile — no LLM judge. It's a focused developer/testing tool (not a general-purpose agent or framework), with open-source scorecards for Prisma, the Vercel AI SDK, and Zod.

- Site: https://sdkproof.dev
- Repo: https://github.com/Kalpitrathore/sdkproof

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
