### PR TITLE
Add Vynix to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [Vynix](https://www.vynix.in) - Visual feedback platform and MCP server that provides AI coding agents with structured browser context, annotations, screenshots, DOM, console logs, and network requests from live websites.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds **Vynix** to Agent Infrastructure -> Configuration & Context Management.

Vynix is a developer tool that provides AI coding agents with structured browser context from live websites. You click any element on a running site, and Vynix captures annotations, screenshots, DOM, console logs, and network requests, then exposes them to AI coding agents (Claude Code, Cursor, Windsurf, Copilot) through an MCP server.

Sits alongside existing context-provider entries in this section such as Context7 and Domscribe.

- Homepage: https://www.vynix.in
- MCP docs: https://www.vynix.in/mcp

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
