### PR TITLE
Add whatbroke to CI/CD & Testing Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) — CLI that diffs AI agent behavior between two runs: dropped tool calls, drifted arguments, cost/latency regressions, and outcome flips after a model or prompt change. Records traces via proxy or SDK, rates flaky findings across multiple samples, and gates CI with exit codes. Offline and deterministic, no API keys.
 
 ---
 


### PR DESCRIPTION
## Description

Adds whatbroke, an open-source CLI I built that diffs an AI agent's behavior between two recorded runs. Point it at a trace from before and after a model swap or prompt change and it reports dropped tool calls, drifted arguments, reordered tools, cost/latency regressions, and outcome flips. It records traces through a local proxy (zero code changes) or a Node SDK, rates findings across multiple samples so pre-existing flakiness gets demoted, and exits nonzero on breaking findings so it can gate CI. MIT, TypeScript, on npm as whatbroke-cli.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries