### PR TITLE
Add Unpeel

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
 - [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
-- [Unpeel](https://unpeel.com) — Native macOS app to run and supervise multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, and more) with persistent terminals that survive app restarts, git worktree isolation, attention notifications, and iPhone remote control via a self-hosted E2E-encrypted relay. Free download, Pro subscription for remote access.
+- [Unpeel](https://unpeel.com) — Native macOS app built on the Ghostty terminal engine to run and remote-control multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, and more): persistent terminals that survive app restarts, git worktree isolation, attention notifications, and iPhone remote control via a self-hosted E2E-encrypted relay. Free download, Pro subscription for remote access.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
 - [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
+- [Unpeel](https://unpeel.com) — Native macOS app to run and supervise multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, and more) with persistent terminals that survive app restarts, git worktree isolation, attention notifications, and iPhone remote control via a self-hosted E2E-encrypted relay. Free download, Pro subscription for remote access.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [Unpeel](https://unpeel.com) to **Desktop & Mobile Applications** (appended at the end of the section, like recent additions).

Unpeel is a native macOS app for running and supervising multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, Amp, OpenCode, Cline, and more): persistent terminal sessions that survive app restarts, git worktree isolation for parallel agents, busy/attention notifications, and remote control from an iPhone via a self-hosted end-to-end-encrypted relay. Free download; Pro subscription unlocks remote access. It fits this section alongside Conductor, Clave, and Parallel Code as a native agent-orchestration app.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries