### PR TITLE
Add gate.cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [gate.cat](https://github.com/BGMLAI/gate.cat) — Deterministic, fail-closed action veto for AI coding agents. Blocks irreversible shell commands (rm -rf, DROP TABLE, terraform destroy) before they run, with no LLM in the veto path. Works as a Claude Code PreToolUse hook, a gated shell for any CLI agent, or a local OpenAI-API proxy. 71 default policy walls, zero-dependency core, Apache-2.0.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
Adds **gate.cat** to the **Configuration & Context Management (Agent Infrastructure)** section.

Disclosure: I'm the maintainer of gate.cat, so this is a self-submission. It's an early, open-source (Apache-2.0) project, so I kept the entry strictly factual and non-hyperbolic and appended it at the end of the section.

**What it is:** a deterministic, fail-closed action veto for AI coding agents. It blocks irreversible shell commands (`rm -rf`, `DROP TABLE`, `terraform destroy`, secret exfiltration) before they run, with no LLM in the veto path (so a prompt injection can't talk it into allowing something). Three integration modes: a Claude Code PreToolUse hook, a gated shell for any CLI agent, or a local OpenAI-API proxy.

Repo: https://github.com/BGMLAI/gate.cat · `pip install gate.cat` · https://gate.cat

Happy to adjust wording or placement to match your conventions.