### PR TITLE
Add text2diagram to Documentation Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Tools that generate commit messages and PR descriptions from diffs:
 Tools that auto-generate documentation, diagrams, and changelogs from source code:
 
 - [DiagramGPT](https://www.eraser.io/diagramgpt) — Free AI web app that generates flowcharts, ER diagrams, cloud architecture, and sequence diagrams from text or code.
+- [text2diagram](https://text2everything.vip) — Free AI web app that generates Mermaid flowcharts, sequence diagrams, ERDs, class diagrams, state diagrams, mindmaps, and Gantt charts from plain English or Chinese. Output is validated against the real Mermaid parser and stays editable as code, with a chat mode that asks clarifying questions before drawing. Exports SVG, PNG, Markdown, and OPML. No signup.
 - [DocuPilot](https://docupilot-alpha.vercel.app) — GitHub App that auto-updates README, CHANGELOG, and API docs on every push using AI.
 - [DocuWriter.ai](https://www.docuwriter.ai/) — AI-powered web app to generate automated Code & API documentation from your source code files.
 - [EkLine](https://ekline.io/) — AI-powered documentation tool with quality checks, style guide enforcement, and automatic doc generation.


### PR DESCRIPTION
## Description

Adding [text2diagram](https://text2everything.vip) to the **Documentation Generation** section, right after DiagramGPT (the closest match — both generate diagrams from text).

**What it is** — a free AI web app that turns plain English or Chinese into 7 diagram types:

- flowchart
- sequence diagram
- ERD
- class diagram
- state diagram
- mindmap
- Gantt chart

**What makes it different from DiagramGPT** — a **chat mode** where the AI asks 2-3 clarifying questions about actors, events, and edge cases before drawing (helpful for complex flows where one prompt misses details). Also exports Markdown / OPML in addition to SVG / PNG.

No signup. Free daily rate limit.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries