### PR TITLE
Add hwatu — visual verification browser for coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [hwatu](https://github.com/hongnoul/hwatu) — Open-source visual verification browser for AI coding agents. Daemon-based WebKitGTK with ~13ms window spawn lets agents render pages, run DOM eval, take screenshots and pixel-diffs to verify UI changes, and hand the live session to a human. Linux/Wayland, MCP built in.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [hwatu](https://github.com/hongnoul/hwatu) to CI/CD & Testing Automation.

hwatu is an open-source visual verification browser for AI coding agents. A daemon owns a WebKitGTK engine with a prewarmed WebView pool (~13ms window spawn), so agents can render the pages they build, run DOM eval, take screenshots and pixel-diffs to verify UI changes, and hand a live session to a human for CAPTCHAs or visual judgment. Rust, Linux/Wayland, MCP server built in. MIT.

Disclosure: I'm the author.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries