### PR TITLE
Add PinkCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
 - [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
+- [PinkCode](https://github.com/3xian/PinkCode) — Open-source desktop GUI for Grok Build that runs multiple coding-agent sessions in parallel and visualizes task activity, token and credit usage, file changes, and permissions over ACP.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [PinkCode](https://github.com/3xian/PinkCode), an open-source desktop GUI for Grok Build. It lets developers run multiple coding-agent sessions in parallel and inspect live task activity, token and credit usage, file changes, and permissions over ACP.

Disclosure: I maintain PinkCode.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries