### PR TITLE
Add docker-claudebox

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Secure isolated environments for running AI coding agents with controlled access
 - [FlyDex](https://flydex.net) — Browser-first remote control plane for local Codex sessions with QR pairing, approvals, and machine continuity.
 - [mirrord](https://github.com/metalbear-co/mirrord) — Per-agent isolation inside a shared Kubernetes cluster: traffic filters, DB branches, and Kafka queue splits via the mirrord Operator. Six [Claude Code skills](https://github.com/metalbear-co/skills) cover quickstart, config, operator setup, CI, DB branching, and Kafka splitting; install via `/plugin marketplace add metalbear-co/skills`.
 - [AgentTier](https://github.com/agenttier/agenttier) — Open-source, Kubernetes-native sandbox runtime for AI coding agents (Claude Code, LangGraph, OpenHands). Each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation; runs in interactive `mode: code` (browser terminal) or `mode: agent` (REST `/configure` + SSE-streaming `/invoke`). Apache-2.0.
+- [docker-claudebox](https://github.com/psyb0t/docker-claudebox) — Run Claude Code in a Docker container exposing an OpenAI-compatible API, an MCP server, and a Telegram bot interface.
 
 ### Configuration & Context Management
 


### PR DESCRIPTION
## Description

Adds [docker-claudebox](https://github.com/psyb0t/docker-claudebox) to **Agent Infrastructure › Sandboxing & Isolation** — a direct peer of the existing brood-box / Open Agent / AgentTier entries. It runs Claude Code inside a Docker container and exposes it over an OpenAI-compatible API, an MCP server, and a Telegram bot interface.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries