### PR TITLE
Add agmem (Configuration & Context Management)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [agmem](https://github.com/albedoweb/agmem) — Local-first project memory CLI for coding agents. Indexes repo structure (Terraform, Python, Go, YAML, Markdown) into greppable JSONL and serves task-relevant context via BM25 with optional local embeddings; tracks staleness via source hashes. Shell-out integration with Claude Code, Codex, Cursor, and Aider. No LLM calls, no server. Apache-2.0.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds **agmem** to Configuration & Context Management — a local-first project memory CLI for coding agents. It indexes repo structure (Terraform, Python, Go, YAML, Markdown) into plain JSONL and serves task-relevant context to any agent via shell-out (Claude Code, Codex, Cursor, Aider). BM25 retrieval with optional local embeddings, staleness tracking via source hashes, no LLM calls, no server. Apache-2.0.

## Checklist

- [x] The entry is a tool that uses AI — it is a context/memory layer purpose-built for AI coding agents (same category as ctxlint, pi-steering-hooks in this section)
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries