### PR TITLE
Add OpenJet to Terminal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
+- [OpenJet](https://github.com/L-Forster/open-jet) — Terminal coding agent built for local models rather than cloud APIs. Setup profiles your hardware, picks a quantization that fits available VRAM, and configures llama.cpp. The harness targets limited context windows with chat/code/review/debug modes, persistent step state, and automatic context condensing. Runs fully offline.
 
 ### CLI Utilities
 


### PR DESCRIPTION
## Description

Adds OpenJet to the Terminal Agents section.

OpenJet is an open-source terminal coding agent built for locally hosted models rather than hosted APIs. Setup profiles the machine, selects a quantization that fits available VRAM, configures llama.cpp, and starts the agent loop. The harness targets limited context windows: chat/code/review/debug modes, step state persisted outside the context, automatic condensing, and model unload/reload on constrained hardware.

AGPL-3.0, distributed on PyPI as `open-jet`. Runs fully offline with no API calls.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
