### PR TITLE
Add langhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Secure isolated environments for running AI coding agents with controlled access
 - [FlyDex](https://flydex.net) — Browser-first remote control plane for local Codex sessions with QR pairing, approvals, and machine continuity.
 - [mirrord](https://github.com/metalbear-co/mirrord) — Per-agent isolation inside a shared Kubernetes cluster: traffic filters, DB branches, and Kafka queue splits via the mirrord Operator. Six [Claude Code skills](https://github.com/metalbear-co/skills) cover quickstart, config, operator setup, CI, DB branching, and Kafka splitting; install via `/plugin marketplace add metalbear-co/skills`.
 - [AgentTier](https://github.com/agenttier/agenttier) — Open-source, Kubernetes-native sandbox runtime for AI coding agents (Claude Code, LangGraph, OpenHands). Each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation; runs in interactive `mode: code` (browser terminal) or `mode: agent` (REST `/configure` + SSE-streaming `/invoke`). Apache-2.0.
+- [langhost](https://github.com/langhost/langhost) — MIT-licensed self-hosted runtime for the LangGraph Agent Server on Postgres and Redis. Serves existing `langgraph.json` graphs with LangSmith Studio, langgraph-sdk, MCP, and Agent Protocol—no application rewrites.
 
 ### Configuration & Context Management
 


### PR DESCRIPTION
Adds langhost under Agent Infrastructure → Sandboxing & Isolation: MIT self-hosted LangGraph Agent Server (Postgres + Redis).