### PR TITLE
Add CodeRyo Studio to Desktop & Mobile Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Web utilities for quick code generation, language translation, and regex creatio
 
 Native apps for AI-powered coding, terminal enhancement, and agent orchestration:
 
+- [CodeRyo Studio](https://jason920612.github.io/coderyo-studio-site/) — Local AI coding agent workstation / control plane (multi-session, zh-TW first, phone mirror, BYO keys).
 - [Warp](https://www.warp.dev/) — AI-powered terminal with team knowledge sharing and command suggestions.
 - [Pieces](https://pieces.app/) — AI-powered snippet manager and context engine with desktop app and browser extension.
 - [Memex](https://memex.tech/) — Build anything in any stack, with just natural language, on your desktop.


### PR DESCRIPTION
## Description

Adds **CodeRyo Studio** under Desktop & Mobile Applications: a local AI coding agent workstation / control plane (multi-session, zh-TW first, phone mirror, BYO keys). Landing: https://jason920612.github.io/coderyo-studio-site/

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries