### PR TITLE
Add rote to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [rote](https://github.com/trevhud/rote) - CLI that compiles a proven agent skill (a SKILL.md plus references) into a typed, deterministic pipeline. Fixed logic becomes reviewable Python or TypeScript with per-step tests, while judgment steps stay as typed LLM-judge signatures. Emits DBOS, Temporal, Cloudflare Workflows, Inngest, or plain Python/TS, and can serve compiled pipelines as MCP tools. Apache-2.0, `pip install rote-cli`.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [rote](https://github.com/trevhud/rote) to Terminal > CLI Utilities.

rote is an open source CLI (Apache-2.0, Python 3.11+, `pip install rote-cli`) that compiles a proven agent skill, meaning a SKILL.md plus its references, into a typed, deterministic pipeline. Fixed logic is extracted into reviewable Python or TypeScript with per-step tests, and only the steps that genuinely need judgment stay as typed LLM-judge signatures, so most of the pipeline runs without an LLM in the loop. It emits DBOS, Temporal, Cloudflare Workflows, Inngest, or plain Python/TS, and can serve compiled pipelines as MCP tools via `rote serve`.

It uses AI at compile time (an LLM compiler agent reads the skill and classifies each step) and is aimed at developers who already run agent skills and want the repeatable parts to become normal, testable code.

This is a new project without significant traction yet.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)