### PR TITLE
Add THROUGHLINE to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [THROUGHLINE](https://github.com/hellomyoh/throughline) — Spec-driven development layer for coding agents, made of markdown and git with no runtime, CLI, or dependencies. Personas review each spec before code, and an append-only single source of truth keeps decisions consistent across sessions. Works with Claude Code, Codex, and Cursor. English and Korean, MIT.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds [THROUGHLINE](https://github.com/hellomyoh/throughline) to **Agent Infrastructure → Configuration & Context Management**, alongside similar entries such as GAAI Framework, Spartan AI Toolkit, and claude-code-pro-pack.

THROUGHLINE is a spec-driven development layer for coding agents, made of markdown and git with no runtime, CLI, or dependencies. It generates `AGENTS.md` / `CLAUDE.md` and a spec tree that coding agents load on every run. Personas review each spec from fixed viewpoints before code is written, and an append-only single source of truth keeps earlier decisions retrievable in later sessions rather than silently overwritten. Works with Claude Code, Codex, and Cursor. English and Korean docs, MIT licensed.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

On the first box, to be precise: THROUGHLINE is not itself an AI product — it is a configuration and context layer that drives AI coding agents, which is what this subsection collects. Flagging it explicitly so you can judge the fit rather than take the checkbox at face value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)