### PR TITLE
Add ai-economics-mcp to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [ai-economics-mcp](https://github.com/pich/ai-economics-mcp) — MCP server that answers cost and energy questions inside the agent loop instead of after the fact: token cost across GPT/Claude/Gemini/DeepSeek, context-window sizing, fully-loaded agent-hour cost, model-routing savings, and joules and CO₂ per verified task. 12 calculators, also a free keyless HTTP API with an OpenAPI 3.1 spec. MIT, by Michał Piszczek ([piszczek.pl/tools](https://piszczek.pl/tools)).
 
 ---
 


### PR DESCRIPTION
## Description

Adds [ai-economics-mcp](https://github.com/pich/ai-economics-mcp) to the end of **Agent Infrastructure → Usage Analytics & Cost Tracking**, by Michał Piszczek ([piszczek.pl/tools](https://piszczek.pl/tools)).

The section currently covers tools that report what an agent run *cost* after it happened. This one sits on the other side of the decision: it exposes 12 calculators as MCP tools, so the agent (or the developer at the prompt) can price the work before running it — token cost across GPT/Claude/Gemini/DeepSeek with prompt-cache discount, context-window sizing, fully-loaded agent-hour cost including human review, model-routing savings, and energy and CO₂ per *verified* task.

It complements the neighbouring entries rather than duplicating them: CodeCosts and ai-coding-tools-pricing cover subscription plan pricing, and TokenWise routes and logs after the fact.

- npm `@michalpiszczek/ai-economics-mcp` — runs with `npx -y @michalpiszczek/ai-economics-mcp`
- Official MCP Registry: `pl.piszczek/ai-economics`
- Also a free keyless HTTP API with an OpenAPI 3.1 spec, so it is usable without MCP
- MIT. Every formula and its source is documented; no key, no telemetry, inputs are never stored

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
