### PR TITLE
docs: add Pixel Pet

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
 
 ---
+- [Pixel Pet](https://letmethink.cc/app/pixel-pet/) - Turn a personality description into a deterministic ASCII pixel companion in the browser.
 
 ## Automated Workflows
 


### PR DESCRIPTION
Hi! I'd like to suggest adding Pixel Pet to this list.

- [Pixel Pet](https://letmethink.cc/app/pixel-pet/) — A free browser experience that turns a personality description into a deterministic ASCII pixel companion.

I reviewed the list and believe this project fit the selected section. Happy to adjust the wording or placement to match the maintainers' preference.

Thanks for maintaining this resource.