### PR TITLE
Add cowork-to-code-bridge to Sandboxing & Isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Secure isolated environments for running AI coding agents with controlled access
 - [FlyDex](https://flydex.net) — Browser-first remote control plane for local Codex sessions with QR pairing, approvals, and machine continuity.
 - [mirrord](https://github.com/metalbear-co/mirrord) — Per-agent isolation inside a shared Kubernetes cluster: traffic filters, DB branches, and Kafka queue splits via the mirrord Operator. Six [Claude Code skills](https://github.com/metalbear-co/skills) cover quickstart, config, operator setup, CI, DB branching, and Kafka splitting; install via `/plugin marketplace add metalbear-co/skills`.
 - [AgentTier](https://github.com/agenttier/agenttier) — Open-source, Kubernetes-native sandbox runtime for AI coding agents (Claude Code, LangGraph, OpenHands). Each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation; runs in interactive `mode: code` (browser terminal) or `mode: agent` (REST `/configure` + SSE-streaming `/invoke`). Apache-2.0.
+- [cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge) — Async file-based bridge that lets a sandboxed agent delegate work to Claude Code on your own machine; no inbound network listener, token-gated, allowlisted scripts only, with per-task timeouts, budget caps, and output redaction.
 
 ### Configuration & Context Management
 


### PR DESCRIPTION
## Description

Adds **cowork-to-code-bridge** to **Agent Infrastructure → Sandboxing & Isolation** (one line, no other changes).

It's an async, file-based bridge that lets an AI coding agent running in a sandbox delegate work to Claude Code on the developer's own machine — builds, test suites, git operations, Docker, anything needing the real toolchain and real credentials. The sandbox and the machine share one bind-mounted directory; a daemon on the machine watches a folder, so there's **no inbound network listener**.

It sits naturally beside the existing entries in that section: like FlyDex it's a control plane for local agent sessions, and like brood-box/AgentTier it's about running coding agents under controlled access — the difference is that the isolation boundary here is a shared directory plus an allowlist rather than a microVM or a Pod. Token-gated, allowlisted scripts only (no arbitrary commands, no path traversal), runs as your user and never `sudo`, with per-task timeouts, budget caps, bounded output, and secret redaction on anything written to the shared directory.

On the template's exclusions specifically: this is **not** a general-purpose agent or framework. It ships no model, no agent loop, and no reasoning of its own — it's plumbing that gives an existing coding agent access to a developer's machine, which is why I've filed it under infrastructure rather than as an agent.

MIT, Python. Docs: [README](https://github.com/abhinaykrupa/cowork-to-code-bridge) · [SECURITY.md](https://github.com/abhinaykrupa/cowork-to-code-bridge/blob/main/SECURITY.md) (states what the model does *not* defend against, too).

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries