### PR TITLE
Add Blume

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ Secure isolated environments for running AI coding agents with controlled access
 
 Tools that manage and sync AI agent configurations, rules, and context across editors:
 
+- [Blume](https://blume.codes/) — Desktop sidecar for coding agents that monitors sessions, surfaces the rules, skills, and hooks shaping each run, and proposes reviewable context improvements while keeping chat history on the user's machine.
 - [Context7](https://context7.com/) — Documentation platform that provides up-to-date, version-specific documentation and code examples for any library directly into Cursor, Claude Code, Windsurf, and other AI coding tools.
 - [ctxlint](https://github.com/YawLabs/ctxlint) — Open-source linter for AI context files (CLAUDE.md, .cursorrules, copilot-instructions.md) that catches stale paths, wrong commands, and token waste by validating against the real codebase.
 - [Entroly](https://github.com/juyterman1000/entroly) - Open-source context optimization engine that cuts AI token costs by 70-95%. Uses submodular knapsack selection and PRISM reinforcement learning to provide the exact context needed to 65+ supported AI coding agents. Features a built-in MCP server, semantic caching, and SimHash deduplication. Apache-2.0.


### PR DESCRIPTION
## Description

Adds Blume to the Configuration & Context Management section.

Blume is a desktop sidecar for coding agents. It monitors agent sessions, surfaces the rules, skills, and hooks shaping each run, tracks usage, and keeps conversation history under local control.

## Disclosure

Blume is our own product, and we use it ourselves.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries