### PR TITLE
Add Bolt to Terminal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
 
+- [Bolt](https://github.com/Bolt-builder/bolt-cli) — Open-source terminal AI agent with persistent cross-session memory, a team of ten specialized agents, background process control, and session sharing. Built on Bun and Effect, with MCP (OAuth) support, ACP for editors, and a desktop app.
+
 ### CLI Utilities
 
 Lightweight command-line tools for AI-assisted commits, shell translation, and workflow automation:


### PR DESCRIPTION
## Description

Adds [Bolt](https://github.com/Bolt-builder/bolt-cli) to the Terminal Agents section. Bolt is an open-source terminal AI coding agent with persistent cross-session memory, ten specialized agents, background process control, MCP (OAuth) support, and an ACP server for editors.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries