### PR TITLE
Add Latchkey to CI/CD & Testing Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [Latchkey](https://latchkey.dev) — Managed GitHub Actions runners where agents diagnose and repair failing build steps during the run. Failures it can't fix are handed to your coding agent over MCP with the root cause and full logs.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **Latchkey** to *Automated Workflows > CI/CD & Testing Automation*.

Managed GitHub Actions runners where agents diagnose and repair a failing build step during the run: registry timeouts, Docker rate limits, OOM kills, full disks, missing packages. Real defects such as compile errors and failing tests are never retried or masked; those are handed to the developer's own coding agent over MCP with the root cause, the exact failing file and full logs.

Nearest existing entries are Fine ("automate self-healing CI/CD") and TraceRoot AI.

Disclosure: I'm a co-founder.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries