### PR TITLE
Add agents-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [agents-cli](https://github.com/phnx-labs/agents-cli) — One CLI to install, pin, and run Claude Code, Codex, Gemini CLI, Cursor, OpenCode and peers; shared skills/MCP/rules, teams, sessions, fleet dispatch.
 
 ---
 


### PR DESCRIPTION
## Description

Add [agents-cli](https://github.com/phnx-labs/agents-cli) under **Terminal → CLI Utilities**.

agents-cli installs and version-pins AI coding-agent harnesses (Claude Code, Codex, Gemini CLI, Cursor, OpenCode, and peers), syncs shared skills/MCP/rules, and runs teams, sessions, and fleet dispatch from one CLI. It is a manager of agents, not a coding agent itself — so CLI Utilities rather than Terminal Agents.

- Repo: https://github.com/phnx-labs/agents-cli
- npm: `@phnx-labs/agents-cli`
- License: Apache-2.0
- Stars (live `gh api`): **14**

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
