### PR TITLE
Add MergeFix to PR & Code Review Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Integrations that automatically review pull requests and suggest code fixes:
 - [PR Triage](https://pr-triage-web.vercel.app) — Open source PR evaluation tool that scores pull requests on six quality dimensions with diff evidence. BYOK, MIT licensed.
 - [prpack-action](https://github.com/Lucas2944/prpack-action) — GitHub Action that runs prpack on every PR, uploads the packed markdown as an artifact, and posts a summary comment. MIT.
 - [Issue AI Agent](https://github.com/alexyan0431/issue-ai-agent) — Open source GitHub Action that auto-classifies, labels, and replies to issues using AI. Detects duplicates and handles follow-up comments. Supports Claude, OpenAI, and OpenAI-compatible APIs (BYOK). MIT licensed.
+- [MergeFix](https://mergefix.com) — Audits a site for SEO, performance, accessibility, and security issues, then opens a real GitHub pull request with the fixes. Also offers a "Migrate & Own" flow to move an AI-built app (Lovable, Bolt, Replit, etc.) into a repo you fully control.
 
 ### CI/CD & Testing Automation
 


### PR DESCRIPTION
## Description

Adds MergeFix to the PR & Code Review Bots section. MergeFix audits a site for SEO, performance, accessibility, and security issues, then opens a real GitHub pull request with the fixes, matching the format of neighboring entries in this section.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries