### PR TITLE
Add Nexus Shell to Desktop & Mobile Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
 - [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
+- [Nexus Shell](https://nexusshell.app/agent-bridge) — Native macOS SSH workspace with an AI command assistant and an opt-in MCP bridge that lets user-approved Claude Code, Codex, and Cursor agents operate visible SSH terminals and SFTP without receiving stored credentials.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [Nexus Shell](https://nexusshell.app/agent-bridge) to **Desktop & Mobile Applications**.

Nexus Shell is a native macOS SSH workspace with two developer-focused AI
features: a bring-your-own-provider command assistant for terminal diagnosis,
explanations, and command suggestions; and an opt-in MCP bridge that lets
user-approved Claude Code, Codex, and Cursor agents operate visible SSH
terminals and SFTP without receiving stored credentials.

The Agent Bridge is available in the direct-download and Homebrew builds, not
the sandboxed TestFlight / Mac App Store build.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

## Verification and disclosure

- Confirmed there is no existing Nexus Shell entry.
- Confirmed the linked Agent Bridge documentation returns HTTP 200 and states
  the credential, consent, visible-terminal, and distribution boundaries used
  in the description.
- This PR changes one README line only; `git diff --check` passes.
- I am the Nexus Shell developer. Codex assisted with source verification,
  candidate screening, validation, and drafting this contribution.
