### PR TITLE
Add memcode to Terminal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
+- [memcode](https://github.com/memcode-ai/memcode) — The coding agent that remembers your repo. Keeps persistent per-project memory in a local .memcode store (subsystems, prior work, failed approaches, corrected preferences) so sessions don't start from zero. Single Go binary with a full TUI; runs on your own API keys, a hosted gateway, or local Ollama; ships an MCP memory server. Self-hostable, MIT.
 
 ### CLI Utilities
 


### PR DESCRIPTION
## Description

Adds **memcode** to Terminal → Terminal Agents (alongside Claude Code, Codex CLI, Aider). memcode is a terminal-native, developer-focused AI coding agent: a single Go binary with a full TUI that keeps persistent per-project memory in a local `.memcode` store (subsystems, prior work, failed approaches, corrected preferences) so sessions do not start from zero. Runs on your own API keys, a hosted gateway, or local Ollama; also ships an MCP memory server. Self-hostable, MIT.

Repo: https://github.com/memcode-ai/memcode

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries