### PR TITLE
Add BitFun to Desktop & Mobile Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
 - [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
+- [BitFun](https://github.com/GCWing/BitFun) — Open-source cross-platform desktop coding agent that plans, edits, tests, reviews, and commits in real Git repositories, with terminal, browser, remote-workspace, and MCP support.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [BitFun](https://github.com/GCWing/BitFun) to **Desktop & Mobile Applications**.

BitFun is an open-source, cross-platform desktop coding agent. Its developer workflow plans changes, edits files, runs tests, performs code review, and commits inside real Git repositories; it also provides terminal, browser, remote-workspace, and MCP integration. The desktop-app section is a more precise fit than AI-Native IDEs because BitFun is an agent workspace rather than a VS Code-style editor.

This is a project self-submission made on behalf of BitFun.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
- [x] The canonical public repository is linked
- [x] The README and public PR/issue history were searched for duplicates
