### PR TITLE
Add Forge to Terminal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
+- [Forge](https://github.com/NorviaLabs/forge) — Open-source AI coding agent that unifies agent, editor, file explorer, and shell in one keyboard-driven terminal TUI. Built-in Vim-style editor, approval-aware command execution, MCP support, and durable SQLite session journal with resume.
 
 ### CLI Utilities
 


### PR DESCRIPTION
## Description

Adds [Forge](https://github.com/NorviaLabs/forge) — an open-source terminal AI coding agent that unifies agent, editor, file explorer, and shell in one keyboard-driven TUI workspace, with approval-aware command execution, MCP support, and durable session resume.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries