### PR TITLE
Add Atomic Agent to Terminal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) — Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine through a llama.cpp fork. Ships with 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory. No account or API key needed to install. Works on macOS, Linux, and Windows. MIT licensed.
 
 ### CLI Utilities
 


### PR DESCRIPTION
## Description

Hi! I'm the CPO of Atomic Agent. Adding us to **Terminal Agents**, framed strictly as a developer coding tool (not a general-purpose assistant).

Atomic Agent is a local-first CLI and TUI coding agent. It runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key needed to install. It generates code, runs shell commands, and manages multi-file workflows with 56 built-in developer tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory. Works on macOS, Linux, and Windows. MIT licensed.

Links: [Repo](https://github.com/AtomicBot-ai/atomic-agent) · [Site](https://atomicagent.io) · [Docs](https://atomicagent.io/docs) · Install `curl -fsSL https://atomicagent.io/install | sh`

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
