### PR TITLE
Add Job Seeker to Specialized Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,12 @@ Tools that auto-generate documentation, diagrams, and changelogs from source cod
 - [EkLine](https://ekline.io/) — AI-powered documentation tool with quality checks, style guide enforcement, and automatic doc generation.
 - [Changenotes](https://changenotes.app) — AI-powered changelog generator. Connects to GitHub, auto-generates categorized changelogs from commits and PRs on every release. Free tier available, Pro $9/mo.
 
+### Career & Job Search
+
+Tools that use AI agents to automate job search workflows:
+
+- [Job Seeker](https://github.com/galiprandi/job-seeker) — Open source markdown skills that turn any coding agent (Claude Code, Cursor, Devin, opencode) into a job search assistant. Searches LinkedIn, fills Easy Apply forms from Postgres, tracks applications in a kanban pipeline, and drafts recruiter replies with an anti-LLM style checklist. MIT licensed.
+
 ---
 
 ## Resources


### PR DESCRIPTION
## Description

Adds [Job Seeker](https://github.com/galiprandi/job-seeker) under a new "Career & Job Search" subsection in Specialized Tools.

Job Seeker is an open source collection of markdown skills that turns any coding agent (Claude Code, Cursor, Devin, opencode) into a job search assistant. It searches LinkedIn with Must/Strong/Nice preference filters, fills Easy Apply forms from a Postgres database, tracks applications in a kanban pipeline with a visual dashboard, drafts recruiter replies that pass an anti-LLM style checklist, and ships a strategy system with 4 levels (passive, selective, active, aggressive). MIT licensed.

There was no existing category for AI-powered job search tools, hence the new subsection.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
