### PR TITLE
Add claude-repo-audit to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [claude-repo-audit](https://github.com/Joopinhontas/claude-repo-audit) - Grades any Git repo and returns a scorecard: secret-leak scan (real leaks vs demo fixtures), hygiene, maintainability, and a Vibe Score for how much a codebase reads as unreviewed AI-generated code. Claude skill plus a zero-dependency Python scanner; ships an SVG scorecard badge. Local, MIT.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adds **claude-repo-audit** under `### Codebase Intelligence`. It grades any Git repo and returns a scorecard: a secret-leak scan that separates real leaks from demo/test fixtures, a hygiene audit, a maintainability read, and a Vibe Score measuring how much a codebase reads as unreviewed AI-generated code. Global grade is A-F. Runs as a Claude skill (the model does the craft read) or a standalone stdlib-only Python scanner, and emits an SVG scorecard badge. Local-first, MIT, zero runtime deps.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
