### PR TITLE
Add Webcmd to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [Webcmd](https://github.com/agentrhq/webcmd) — CLI that turns websites, browser sessions, and local tools into deterministic command surfaces for coding agents. Learns a site once, then reuses it as installable per-site commands. Node, Apache-2.0.
 
 ---
 


### PR DESCRIPTION
## Description

Adds Webcmd to Terminal > CLI Utilities.

Webcmd turns websites, browser sessions, and local tools into deterministic
command surfaces for coding agents. It drives a real browser (built on
playwright-core) to learn how a site is navigated once, then compiles that
into installable per-site commands the agent reuses instead of re-exploring
the page on every run. Works with Claude Code, Codex, and similar harnesses
via `webcmd skills add`. Node, Apache-2.0.

Disclosure: I contribute to this project.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries