### PR TITLE
Add SandBase CLI to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [SandBase CLI](https://github.com/sandbaseai/cli) — Open-source CLI that connects Claude Code, Codex, Cursor, Windsurf, and other MCP clients to 2,000+ AI models and APIs without requiring separate provider API keys.
 
 ---
 


### PR DESCRIPTION
## Description

Adds SandBase CLI to **CLI Utilities**. It is an open-source developer tool that connects Claude Code, Codex, Cursor, Windsurf, and other MCP clients to 2,000+ AI models and APIs through one CLI integration.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

Disclosure: I am affiliated with SandBase, and this submission was prepared with AI assistance.