### PR TITLE
Add Canopy to context management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Secure isolated environments for running AI coding agents with controlled access
 Tools that manage and sync AI agent configurations, rules, and context across editors:
 
 - [Context7](https://context7.com/) — Documentation platform that provides up-to-date, version-specific documentation and code examples for any library directly into Cursor, Claude Code, Windsurf, and other AI coding tools.
+- [Canopy](https://canopy.8starlabs.com) — Interactive architecture maps that turn your stack, dependencies, and costs into context your AI coding agents can use.
 - [ctxlint](https://github.com/YawLabs/ctxlint) — Open-source linter for AI context files (CLAUDE.md, .cursorrules, copilot-instructions.md) that catches stale paths, wrong commands, and token waste by validating against the real codebase.
 - [Entroly](https://github.com/juyterman1000/entroly) - Open-source context optimization engine that cuts AI token costs by 70-95%. Uses submodular knapsack selection and PRISM reinforcement learning to provide the exact context needed to 65+ supported AI coding agents. Features a built-in MCP server, semantic caching, and SimHash deduplication. Apache-2.0.
 - [lean-ctx](https://leanctx.com) — Open-source context runtime for AI coding agents. MCP server (optional shell hook) that compresses file reads, shell output, and codebase search to reduce token usage, often 60–99% on supported workflows. 46 tools, session caching, AST-aware compression for 18 languages, 90+ shell patterns. Apache-2.0.


### PR DESCRIPTION
## Description

Add Canopy to Configuration & Context Management. Canopy provides interactive architecture maps that turn a stack, dependencies, and costs into context AI coding agents can use.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

## About Canopy

[Canopy](https://canopy.8starlabs.com/) maps engineering and AI systems, then exports the resulting project context as Markdown, CLAUDE.md, and AGENTS.md files for AI coding tools. It is designed to make architecture, dependencies, and costs easier for developers and agents to understand.

Please review the site: [canopy.8starlabs.com](https://canopy.8starlabs.com/)

## Disclosure

I am the maintainer of Canopy, the project being submitted in this PR.