### PR TITLE
Add Datadef to Documentation Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Tools that generate commit messages and PR descriptions from diffs:
 
 Tools that auto-generate documentation, diagrams, and changelogs from source code:
 
+- [Datadef](https://datadef.io) — AI that turns a connected repo into an architecture diagram and an architecture.md, kept in sync daily. Terraform repos are parsed file-by-file; includes an MCP server for Claude Code and Cursor. Free tier available.
 - [DiagramGPT](https://www.eraser.io/diagramgpt) — Free AI web app that generates flowcharts, ER diagrams, cloud architecture, and sequence diagrams from text or code.
 - [DocuPilot](https://docupilot-alpha.vercel.app) — GitHub App that auto-updates README, CHANGELOG, and API docs on every push using AI.
 - [DocuWriter.ai](https://www.docuwriter.ai/) — AI-powered web app to generate automated Code & API documentation from your source code files.


### PR DESCRIPTION
## Description

Adds Datadef to the Documentation Generation section (alphabetical position, before DiagramGPT).

Datadef auto-generates both the architecture diagram and the architecture.md from a connected GitHub/GitLab/Azure DevOps repository, and keeps them regenerated on a daily sync. Terraform repositories get a dedicated parser (every .tf file, no init or state needed). Diagrams embed as live images in READMEs, and an MCP server lets Claude Code/Cursor create and update diagrams from inside an agent session.

Disclosure: I am the founder.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQQUBpBwT9XNcHzVHmRaA3