### PR TITLE
Add Loadout to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [Loadout](https://github.com/migsilva89/loadout) — Native macOS app for inspecting and managing coding assistant assets, including skills, slash commands, subagents, plugins, and MCP servers, with usage counts read from session logs. Covers Claude Code, Codex, and opencode, and edits the items you own. SwiftUI, macOS 15+, MIT.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds [Loadout](https://github.com/migsilva89/loadout) to **Agent Infrastructure → Configuration & Context Management**, as one entry at the end of that section.

Loadout is a native macOS 15+ SwiftUI app that shows what a coding assistant actually loads — skills, slash commands, subagents, plugins and MCP servers — across Claude Code, Codex and opencode in one place. Unlike the config generators and registries already in the section, it reads the session logs to attach a real usage count to each item, so you can see which of your skills and commands are used and which never fire, and it can edit the ones you own. Selecting a skill and pressing **Ask** opens a conversation with the `claude`, `codex` or `opencode` CLI already installed, which proposes edits to that skill for you to accept one at a time.

MIT licensed, free and open source, signed and notarised. Website: https://loadout.migsilva.dev

Placed in Configuration & Context Management rather than a coding-agent category on purpose: Loadout is tooling around coding agents rather than an agent itself, and it sits next to comparable entries such as claude-snapshot, Conduit8 and TokRepo.

Nothing else in the list was touched.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries