### PR TITLE
Add Keen Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
+- [Keen Code](https://mochow13.github.io/keen-code/) — Open-source, context-aware terminal coding agent written in Go. Supports multiple providers, skill-driven MCP integration, subagents, Agent Skills, controllable tool-output retention, and hashline edits.
 
 ### CLI Utilities
 


### PR DESCRIPTION
## Description

Adds [Keen Code](https://mochow13.github.io/keen-code/) to **Terminal Agents**.

Keen Code is an open-source, context-aware terminal coding agent written in Go. It supports multiple providers, MCPs, subagents, Agent Skills, controllable tool-output retention, hashline edits, and more.

Two notable capabilities:

- [Turn Memory](https://mochow13.github.io/keen-code/docs/turn-memory.html) keeps multi-turn conversations lean by retaining a configurable subset of tool-interaction signals across turns, while allowing users to control tool-output retention.
- [Skill-driven MCP](https://mochow13.github.io/keen-code/docs/mcp-skills.html) exposes MCP servers through generated Agent Skills instead of loading every MCP tool definition into context upfront.

Repository: https://github.com/mochow13/keen-code

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries