### PR TITLE
Add Wagglet to multi-agent orchestration tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Platforms for running multiple AI coding agents in parallel with workspace isola
 - [Superset](https://superset.sh/) — Code editor for AI agents that orchestrates swarms of Claude Code, Codex, and other CLI-based agents in parallel. Uses isolated git worktrees with universal IDE integration.
 - [Sidecar](https://github.com/marcus/sidecar) — Terminal UI companion for CLI-based coding agents (Claude Code, Cursor, Gemini) with unified conversation history, git integration, task management, and workspace control.
 - [Vibe Kanban](https://vibekanban.com/) — AI-powered Kanban platform for orchestrating autonomous coding agents. Manage agent workflows with visual boards for task delegation and progress tracking.
+- [Wagglet](https://wagglet.com/) — Task handoff and coordination board for human and AI teammates, with model and skill routing, scoped agent access, review, and verified delivery.
 - [OpenASE](https://github.com/pacificstudio/openase) — Open-source ticket-driven platform for orchestrating Claude Code, Codex, and Gemini CLI agents across isolated workspaces and status-based workflows.
 - [Trellis](https://github.com/mindfold-ai/Trellis) — All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
 - [Codex on ChatGPT](https://chatgpt.com/codex) - Web-based multi-agent orchestration, connected to GitHub repositories. Each thread runs in its own sandbox. When tests pass, creates PR for you. Uses OpenAI models.


### PR DESCRIPTION
## Description

Adds Wagglet to the Multi-Agent Orchestration section. Wagglet is a task handoff and coordination board for human and AI teammates, with model and skill routing, scoped agent access, review, and verified delivery.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

## Validation

- Confirmed no existing Wagglet entry or pull request.
- Ran `git diff --check`.