### PR TITLE
Add no_human to Terminal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
+- [no_human](https://github.com/no-human-ai/no_human) — Open-source autonomous agent that takes a ticket (Jira, Linear, monday.com, GitHub or GitLab issue) to a reviewed pull request on your own machine. A second model with no memory of writing the code reviews every change and cites file and line; a tamper guard blocks a net drop in tests or assertions; the agent opens the PR and never merges. Runs on your own Claude subscription, with an OpenAI Codex backend option.
 
 ### CLI Utilities
 


### PR DESCRIPTION
Adding [no_human](https://github.com/no-human-ai/no_human) — **disclosure: I'm the author**.

It's an open-source (MIT) autonomous agent that takes a ticket — Jira, Linear, monday.com, or a GitHub/GitLab issue — to a reviewed pull request, running on your own machine and your own Claude subscription (OpenAI Codex is a second backend option).

What makes it different from the other terminal agents on the list: a **second model with no memory of writing the code** reviews every change and has to cite file and line, a **tamper guard** blocks a net drop in tests or assertions before that review runs, and the agent **opens the pull request and cannot merge it** — the merge verbs are denied to its sessions. Desktop apps for macOS/Windows/Linux, or install from source.

One line added under Terminal Agents, in the section's existing format. Happy to move it to PR & Code Review Bots if you think it fits better there.