### PR TITLE
Add no_human to Terminal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
+- [no_human](https://github.com/no-human-ai/no_human) — Open-source autonomous agent that takes a ticket (Jira, Linear, monday.com, GitHub or GitLab issue) to a reviewed pull request on your own machine. A second model with no memory of writing the code reviews every change and cites file and line; a tamper guard blocks a net drop in tests or assertions; the agent opens the PR and never merges. Runs on your own Claude subscription, with an OpenAI Codex backend option.
 
 ### CLI Utilities
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
-- [no_human](https://github.com/no-human-ai/no_human) — Hand it a ticket and walk away: it plans, writes the change, runs your tests, and a second model that never saw the code being written reviews it and cites file and line. A tamper guard stops it gaming the tests, and it opens the pull request but cannot merge it. Runs on your machine on your own Claude subscription (OpenAI Codex optional); Jira, Linear, monday.com, GitHub and GitLab intake. MIT.
+- [no_human](https://github.com/no-human-ai/no_human) — From ticket to reviewed pull request. Free and open-source, on your machine. Pulls tickets from Jira, Linear, monday.com, GitHub and GitLab, plans the work, writes the change and runs your tests; a second model that never saw the code being written then reviews it and cites file and line. A tamper guard stops it gaming the tests, and it opens the pull request but cannot merge it. Runs on your own Claude subscription (OpenAI Codex optional).
 
 ### CLI Utilities
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
-- [no_human](https://github.com/no-human-ai/no_human) — Open-source autonomous agent that takes a ticket (Jira, Linear, monday.com, GitHub or GitLab issue) to a reviewed pull request on your own machine. A second model with no memory of writing the code reviews every change and cites file and line; a tamper guard blocks a net drop in tests or assertions; the agent opens the PR and never merges. Runs on your own Claude subscription, with an OpenAI Codex backend option.
+- [no_human](https://github.com/no-human-ai/no_human) — Hand it a ticket and walk away: it plans, writes the change, runs your tests, and a second model that never saw the code being written reviews it and cites file and line. A tamper guard stops it gaming the tests, and it opens the pull request but cannot merge it. Runs on your machine on your own Claude subscription (OpenAI Codex optional); Jira, Linear, monday.com, GitHub and GitLab intake. MIT.
 
 ### CLI Utilities
 


### PR DESCRIPTION
## Description

Adds one entry to **Terminal Agents**: [no_human](https://github.com/no-human-ai/no_human) — an open-source (MIT) CLI agent that takes a ticket (Jira, Linear, monday.com, or a GitHub/GitLab issue) to a reviewed pull request on the developer's own machine, running on their own Claude subscription (OpenAI Codex is a second backend option).

What distinguishes it from the other terminal agents already listed: a second model that never saw the code being written reviews every change and cites file and line, a tamper guard blocks a net drop in tests or assertions before that review runs, and the agent opens the pull request but cannot merge it.

Disclosure: I'm the author. One line added, in the section's existing format. Happy to move it to *PR & Code Review Bots* if that fits better.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
