### PR TITLE
Add aicoolies to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Tools that auto-generate documentation, diagrams, and changelogs from source cod
 Curated lists, comparison guides, and configuration templates for AI coding tools:
 
 - [aiforcode.io](https://aiforcode.io) — Expert-curated directory of 42+ AI coding tools with transparent 100-point scoring, head-to-head comparisons, and an interactive tool recommendation quiz. Verified monthly.
+- [aicoolies](https://aicoolies.com) — Hand-tested catalog / knowledge graph of 1280+ AI developer tools, comparisons, reviews, and stacks.
 - [Awesome Code Docs](https://github.com/johnxie/awesome-code-docs) — Curated deep-dive tutorials for open-source AI and developer tooling projects.
 - [AI Coding Compare](https://aicodingcompare.com) — Compare 50+ AI coding assistants with features, pricing, and performance benchmarks.
 - [ClaudeDown](https://claudedown.com) - Real-time Claude AI complaint tracker and outage detector using Twitter/X sentiment data.


### PR DESCRIPTION
## Description

I'm the maker of [aicoolies](https://aicoolies.com).

This is a **Resources** add, not a new IDE/agent/tool row. aicoolies is a hand-tested catalog / knowledge graph of 1280+ AI developer tools (comparisons, reviews, and stacks). It is not a coding agent and it is not itself "a tool that uses AI."

The Resources section already lists catalogs and comparison sites (aiforcode.io, aicodingcompare.com). This entry belongs there.

## Checklist

- [ ] The entry is a tool that uses AI (does not apply: this is a catalog listed under Resources, same as aiforcode.io)
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries