### PR TITLE
Add claude-carbon (carbon footprint tracking for Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [claude-carbon](https://github.com/gwittebolle/claude-carbon) - Tracks the carbon footprint of Claude Code sessions: live CO2 estimate in the status line, per-model reports, and shareable PNG report cards.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [claude-carbon](https://github.com/gwittebolle/claude-carbon) under CLI Utilities: an MIT-licensed companion CLI for Claude Code that tracks the carbon footprint of coding sessions, with a live CO2 estimate in the status line, per-model reports, and shareable PNG report cards. 160+ stars, actively maintained since April 2026, methodology publicly documented. I'm the author.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
