### PR TITLE
Add Disensor to the tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Integrations that automatically review pull requests and suggest code fixes:
 - [PR Triage](https://pr-triage-web.vercel.app) — Open source PR evaluation tool that scores pull requests on six quality dimensions with diff evidence. BYOK, MIT licensed.
 - [prpack-action](https://github.com/Lucas2944/prpack-action) — GitHub Action that runs prpack on every PR, uploads the packed markdown as an artifact, and posts a summary comment. MIT.
 - [Issue AI Agent](https://github.com/alexyan0431/issue-ai-agent) — Open source GitHub Action that auto-classifies, labels, and replies to issues using AI. Detects duplicates and handles follow-up comments. Supports Claude, OpenAI, and OpenAI-compatible APIs (BYOK). MIT licensed.
+- [Disensor](https://disensor.dev) — Open source CI gate for AI code review between two model families. Validates and enforces a versioned record of what the adversarial review could not resolve. No models run, no API keys. MIT licensed.
 
 ### CI/CD & Testing Automation
 


### PR DESCRIPTION
## Description

Adds Disensor under PR & Code Review Bots. It is the enforcement side of AI code review: one model generates, a model from another family attacks the change, and Disensor validates and CI-enforces the residue declaration, a versioned JSON record of how the review ended and what it could not resolve. Open source (MIT), Python CLI plus GitHub Action, no API keys. Method write-up: DOI 10.5281/zenodo.21633495. The project gates its own PRs with it.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries