### PR TITLE
Add aGiTrack to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [aGiTrack](https://github.com/core-aix/agitrack) — Terminal wrapper for Claude Code, Codex, and OpenCode that commits each agent turn to git, writing the prompt, model, and that turn's input/output/cache token counts into the commit message. Token spend stays attributable to the diff that caused it, and a local dashboard breaks down commits, sessions, and cost by author. Apache-2.0, pip install agitrack.
 
 ---
 


### PR DESCRIPTION
## Description

Adds aGiTrack to **Agent Infrastructure → Usage Analytics & Cost Tracking**, appended at the end of the section in the existing entry style.

Disclosure: I'm the author.

aGiTrack (Apache-2.0) is a terminal tool that drives Claude Code, Codex, or OpenCode and commits each agent turn to git automatically. The commit message records the backend, model, and that turn's input, output, cache-read, and cache-write token counts, so token spend stays attributable to the specific diff that produced it. A local dashboard summarises commits, sessions, and cost by author.

Relative to the other entries in this section, which read session logs or statuslines after the fact, the usage record here is written into git history as the work happens, so it survives log rotation and travels with the repository. The trailer format is visible on any recent commit in the repo, e.g. [`c6258c25`](https://github.com/core-aix/agitrack/commit/c6258c25).

It is a developer tool, not a general-purpose agent, framework, or data-analysis tool: it does one thing for people working in a git repository with a coding agent.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
