### PR TITLE
Add Vibe-Coding Prompt Template to Configuration & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+- [Vibe-Coding Prompt Template](https://github.com/KhazP/vibe-coding-prompt-template) — CLI (`npx vibeworkflow`) and prompt set that interviews you about a project, writes the PRD and technical design, then generates `AGENTS.md` and `agent_docs/` for Claude Code, Cursor, Codex, and Gemini CLI. MIT licensed.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds one entry to **Agent Infrastructure → Configuration & Context Management**:

```markdown
- [Vibe-Coding Prompt Template](https://github.com/KhazP/vibe-coding-prompt-template) — CLI (`npx vibeworkflow`) and prompt set that interviews you about a project, writes the PRD and technical design, then generates `AGENTS.md` and `agent_docs/` for Claude Code, Cursor, Codex, and Gemini CLI. MIT licensed.
```

It sits with the other config/context generators already in that section (Caliber, ContextKit, Agentify, intelligence-sync): the deliverable is the agent configuration files, produced from an interview rather than from a codebase scan or an OpenAPI spec.

Not a general-purpose agent, assistant, or framework — it produces no runtime behavior of its own, only the instruction files a coding agent reads. Free and MIT licensed, 2.8k stars, on npm as `vibeworkflow`.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
