### PR TITLE
Add APICostCalc

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [APICostCalc](https://apicostcalc.com/api-bill-health-score.html) — Free web calculator that scores an AI API bill 0-100 on model-task fit, prompt caching, batch API use, and retry waste, with a shareable health card. Also compares pricing across 387+ AI models.
 
 ---
 


### PR DESCRIPTION
Adds [APICostCalc](https://apicostcalc.com/api-bill-health-score.html) to Usage Analytics & Cost Tracking — a free web calculator that scores an AI API bill 0-100 on model-task fit, caching, batching and retry waste (shareable card), alongside a 387-model pricing comparison. Complements the log-parsing CLI tools already listed here with a pre-purchase/self-reported estimator.