### PR TITLE
Add Persona to Desktop and Mobile Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
 - [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
+- [Persona](https://github.com/jayamitkatariya/personacli) — Local-first personal workspace for macOS: notes and tasks as plain Markdown with an AI chat grounded in your own files. Free, open-source (MIT).
 
 ---
 


### PR DESCRIPTION
## Description

Persona is a local-first personal workspace for macOS developers: notes, tasks, and project docs live as plain Markdown files on disk, and a built-in AI chat answers questions grounded in those files (works with Ollama or any OpenAI-compatible API). It fits this list's Desktop Applications section as an AI-powered developer knowledge tool — think Obsidian + codebase-aware chat, MIT licensed.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries