### PR TITLE
Add Recast to Snippet & Utility Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Web utilities for quick code generation, language translation, and regex creatio
 - [JSONFix](https://jsonfix-lake.vercel.app/) — AI-powered JSON repair tool that instantly fixes malformed JSON with missing quotes, trailing commas, and syntax errors.
 - [CronAI](https://cronai-nu.vercel.app/) — Converts plain English schedule descriptions into correct cron expressions using AI.
 - [RegexAI](https://regexai-six.vercel.app/) — Generates working regular expressions from plain English descriptions with explanations. Supports multiple regex flavors.
+- [Recast](https://recast-indol.vercel.app/) — Browser tool that turns messy LLM output into valid JSON and explains each change. Nothing is uploaded.
 
 ---
 


### PR DESCRIPTION
## Description
Adds [Recast](https://recast-indol.vercel.app/) to Web-Based Tools → Snippet & Utility Tools, next to JSONFix / CronAI / RegexAI.

Recast is a developer-focused, in-browser tool for cleaning messy LLM JSON before it hits n8n, Make, Zapier, or an API. It lists every change. Nothing is uploaded.

I am the maker.

## Checklist
- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries