### PR TITLE
Add Symphony to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [Symphony](https://github.com/itsloganmann/symphony) - Live dashboard and 3D repo map of the AI coding agents working across a team. Hooks stream every file edit from Claude Code, Codex, and opencode into Supabase; the board shows per-person cards, collision flags, and a token leaderboard in real time. Self-hosts locally or on Modal. MIT, Python/FastAPI.
 
 ---
 


### PR DESCRIPTION
Adds [Symphony](https://github.com/itsloganmann/symphony), a live dashboard and 3D repo map of the AI coding agents working across a team.

- Hooks stream every file edit from Claude Code, Codex, and opencode into Supabase, so the board updates in real time with no reload.
- Shows per-person cards, collision flags for overlapping edits, and a token leaderboard.
- Self-hosts locally or on Modal with a free Supabase project. MIT, Python/FastAPI.

Placed in Usage Analytics & Cost Tracking next to the other agent observability tools; happy to move it if another section fits better.