### PR TITLE
Add Okto Nexus to the tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Secure isolated environments for running AI coding agents with controlled access
 - [FlyDex](https://flydex.net) — Browser-first remote control plane for local Codex sessions with QR pairing, approvals, and machine continuity.
 - [mirrord](https://github.com/metalbear-co/mirrord) — Per-agent isolation inside a shared Kubernetes cluster: traffic filters, DB branches, and Kafka queue splits via the mirrord Operator. Six [Claude Code skills](https://github.com/metalbear-co/skills) cover quickstart, config, operator setup, CI, DB branching, and Kafka splitting; install via `/plugin marketplace add metalbear-co/skills`.
 - [AgentTier](https://github.com/agenttier/agenttier) — Open-source, Kubernetes-native sandbox runtime for AI coding agents (Claude Code, LangGraph, OpenHands). Each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation; runs in interactive `mode: code` (browser terminal) or `mode: agent` (REST `/configure` + SSE-streaming `/invoke`). Apache-2.0.
+- [Okto Nexus](https://github.com/OktoLabsAI/okto-nexus) — Local-first MCP coordination hub for teams of AI coding agents. Single-winner handoff claims, human-in-the-loop approval, durable messaging with inbox delivery, and governance controls (policies, guardrails, quotas) all run from one local hub with no cloud broker.
 
 ### Configuration & Context Management
 


### PR DESCRIPTION
## Description

Adds Okto Nexus to Agent Infrastructure > Multi-Agent Orchestration. It's a local-first MCP coordination hub for teams of AI coding agents — single-winner handoff claims, human-in-the-loop approval, durable messaging, and governance controls (policies, guardrails, quotas), all from one local hub with no cloud broker. Closest existing neighbors in this section are Shep, MartinLoop, CueAPI, and Bernstein — all coordination/verification layers for coding agents rather than the agents themselves.

## Checklist
- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries