### PR TITLE
Add TheGitAI to Terminal Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Autonomous CLI agents that generate code, execute shell commands, and manage mul
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) — A Claude Code plugin that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration, validation, and cross-model peer review.
 - [cmux](https://github.com/manaflow-ai/cmux) — A Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents. Features notification rings, in-app browser, SSH support, and Claude Code Teams integration.
 - [pi](https://pi.dev/) — Minimal, extensible terminal coding agent. TypeScript extensions, skills, prompt templates, and themes — all shareable as npm packages. Supports multiple LLM providers with a unified API.
+- [TheGitAI](https://thegit.ai) — Autonomous AI coding agent for the terminal. Handles planning, repo-wide implementation, tests, debugging, and web research end to end, with checkpointed edits that reverse cleanly. Runs on multiple frontier models with no provider account or API key of your own.
 
 ### CLI Utilities
 


### PR DESCRIPTION
## Description

Adds TheGitAI to the Terminal → Terminal Agents section.

TheGitAI is an autonomous AI coding agent for the terminal. It plans and implements
changes across a whole repository, runs commands and tests, debugs failures, and pulls
in web research, with every assistant edit checkpointed so it reverses cleanly. It runs
on multiple frontier models and needs no provider account or API key of your own.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

Disclosure: I work on TheGitAI.
