### PR TITLE
Add SandBase CLI to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [SandBase CLI](https://github.com/sandbaseai/cli) — Open-source local CLI and MCP bridge that configures 25 AI clients for access to 2,000+ models and APIs, with OAuth onboarding, diagnostics, and configuration rollback.
 
 ---
 


### PR DESCRIPTION
## Description

Adds SandBase CLI to the CLI Utilities section. SandBase CLI is an open-source local CLI and MCP bridge for configuring 25 AI clients to access a catalog of 2,000+ models and APIs, with OAuth onboarding, diagnostics, and configuration rollback.

Official sources:

- https://github.com/sandbaseai/cli#readme
- https://github.com/sandbaseai/cli/blob/main/LICENSE
- https://github.com/sandbaseai/cli/releases/tag/v0.1.17

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

The change is limited to one README entry, and `git diff --check` passes. AI assistance was used to prepare the contribution; the claims were verified against the official sources above.
