### PR TITLE
Add OrcaCode Review to PR & Code Review Bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Integrations that automatically review pull requests and suggest code fixes:
 - [PR Triage](https://pr-triage-web.vercel.app) — Open source PR evaluation tool that scores pull requests on six quality dimensions with diff evidence. BYOK, MIT licensed.
 - [prpack-action](https://github.com/Lucas2944/prpack-action) — GitHub Action that runs prpack on every PR, uploads the packed markdown as an artifact, and posts a summary comment. MIT.
 - [Issue AI Agent](https://github.com/alexyan0431/issue-ai-agent) — Open source GitHub Action that auto-classifies, labels, and replies to issues using AI. Detects duplicates and handles follow-up comments. Supports Claude, OpenAI, and OpenAI-compatible APIs (BYOK). MIT licensed.
+- [OrcaCode Review](https://github.com/Continuum-AI-Corp/orca-code-review) — GitHub Action that reviews each pull request, posts findings inline on the affected lines, and fails the check on P0/P1 severity. Model, rubric, and merge policy are set outside the workflow YAML; ships a Claude Code skill and plugin for setup.
 
 ### CI/CD & Testing Automation
 


### PR DESCRIPTION
## Description

Adds [OrcaCode Review](https://github.com/Continuum-AI-Corp/orca-code-review) to `PR & Code Review Bots`.

It is a GitHub Action that reviews each pull request, posts findings inline on the affected lines, and fails the check on P0/P1 severity. The reviewing model, the severity rubric, and the merge policy live outside the workflow YAML, so changing review strategy does not mean editing the workflow file. MIT licensed; it also ships a Claude Code skill and plugin for setup and troubleshooting.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries