### PR TITLE
Add Coder Eval to CI/CD & Testing Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [Coder Eval](https://github.com/UiPath/coder_eval) — Open-source harness for testing AI coding agents and their skills in CI. Scores skill-activation precision/recall over labelled prompt suites and fails the build when it regresses, via a published GitHub Action.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **Coder Eval** to `CI/CD & Testing Automation` — one line, no other changes.

**Disclosure:** I maintain this project. Happy to reword or move the entry — say the word.

The section's framing is "tools that generate unit/e2e tests and integrate AI into CI/CD pipelines." Coder Eval is the second half of that: it doesn't generate tests for your app, it tests **the AI coding agent itself** and gates the pipeline on the result.

Concretely: you give it a labelled set of prompts, and it measures whether the agent's skills actually trigger on the ones they claim to handle and stay quiet on the rest. That comes out as suite-level precision / recall / F1, and a published GitHub Action fails the build when the numbers regress. It runs the same suite across Claude Code, Codex, OpenCode and Antigravity, so a drop can be attributed to the skill or to the harness.

Everything else currently in this section is commercial QA SaaS, so this is the open-source, agent-side entry rather than a duplicate of any of them.

- Repo: https://github.com/UiPath/coder_eval — Apache-2.0, 118★, Python
- Docs: https://coder-eval.com/docs
- Action: https://github.com/marketplace/actions/coder_eval

Not a general-purpose agent, assistant, framework, or data-analysis tool — it is a developer testing tool for CI.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
