### PR TITLE
Add Preflight to Usage Analytics & Cost Tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [Preflight](https://github.com/newrelic-experimental/preflight) — MCP server for observing AI coding assistants (Claude Code, Cursor, Windsurf, GitHub Copilot, Amazon Q, Kiro). Per-session cost tracking, efficiency scoring, anti-pattern detection, budget alerts, and a local dashboard, with optional New Relic export.
 
 ---
 


### PR DESCRIPTION
## Description

Adds Preflight, an open-source (Apache-2.0) MCP server that observes AI coding assistants (Claude Code, Cursor, Windsurf, GitHub Copilot, Amazon Q, Kiro): per-session cost tracking, efficiency scoring, anti-pattern detection, budget alerts, and a local dashboard, with optional New Relic export.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries