### PR TITLE
Add Kilawatt Cloud to the list of tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,8 @@ Platforms for running multiple AI coding agents in parallel with workspace isola
 - [Vibe Kanban](https://vibekanban.com/) — AI-powered Kanban platform for orchestrating autonomous coding agents. Manage agent workflows with visual boards for task delegation and progress tracking.
 - [OpenASE](https://github.com/pacificstudio/openase) — Open-source ticket-driven platform for orchestrating Claude Code, Codex, and Gemini CLI agents across isolated workspaces and status-based workflows.
 - [Trellis](https://github.com/mindfold-ai/Trellis) — All-in-one AI framework & toolkit for Claude Code & Cursor. Manages tasks, specs, and multi-agent pipelines.
-- [Codex on ChatGPT](https://chatgpt.com/codex) - Web-based multi-agent orchestration, connected to GitHub repositories. Each thread runs in its own sandbox. When tests pass, creates PR for you. Uses OpenAI models.
+-  [Kilawatt Cloud](https://github.com/KilaWattCloud/kilawatt-mcp.server) -Zero-quota GPU compute orchestration and dynamnic failover gateway.
+- - [Codex on ChatGPT](https://chatgpt.com/codex) - Web-based multi-agent orchestration, connected to GitHub repositories. Each thread runs in its own sandbox. When tests pass, creates PR for you. Uses OpenAI models.
 - [GolemBot](https://github.com/0xranx/golembot) — Unified framework wrapping Claude Code, Cursor, OpenCode, and Codex CLIs behind a single streaming API. Adds IM adapters (Slack, Telegram, Discord, Feishu), Skill system, fleet mode, and HTTP embedding.
 - [Stoneforge](https://stoneforge.ai) — Open-source orchestration for AI coding agents. Run multiple agents in parallel with automatic dispatch, merge, and recovery.
 - [Shep](https://github.com/shep-ai/cli) — Multi-session SDLC control center that orchestrates AI coding agents (Claude Code, Cursor CLI, Gemini) for autonomous feature development with configurable approval gates and a live web dashboard.


### PR DESCRIPTION
## Description
Adds Kilawatt Cloud MCP Server to the list of AI devtools. Kilawatt Cloud provides zero-quota GPU compute orchestration and dry-run node allocation for AI agents.

## Checklist
- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
- [x] I have read the Contributing Guidelines.
- [x] I have added my project in alphabetical order under the correct category.
