### PR TITLE
Add Belay (companion app for AI coding agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Native apps for AI-powered coding, terminal enhancement, and agent orchestration
 - [Onepilot](https://onepilotapp.com) — iOS app for running AI coding agents (Claude Code, Codex CLI, Gemini CLI) on remote servers via SSH. Provides a full terminal with SwiftTerm, agent session management, and mobile access to your dev machines.
 - [Vibe Island](https://vibeisland.app) — Native macOS notch panel for 18 AI coding CLIs (Claude Code, Codex, Gemini, Cursor, Droid, OpenCode, Copilot). Permission prompts appear in the notch, clicking a notification jumps back to the originating terminal pane, and the bar tracks usage limits per provider. Swift 6, AppKit + SwiftUI.
 - [Clave](https://github.com/codika-io/clave) — Native macOS app for managing multiple Claude Code sessions in parallel, with split/grid layouts, session groups, SSH remote sessions, a git panel, conversation history, and usage analytics. Free, open-source (MIT), local-first.
+- [Belay](https://github.com/PerfectoWeb/Belay) — Menu bar app for macOS that detects when AI coding agents (Claude Code, Codex, Copilot CLI, Cline) are active and keeps the Mac awake, letting it sleep again once they finish. Free, source-available, no telemetry.
 
 ---
 


### PR DESCRIPTION
## Description

Adds Belay to the Desktop & Mobile Applications section. Belay is a free, source-available macOS menu-bar app that watches for AI coding agents (Claude Code, Codex, Copilot CLI, Cline, with presets for Gemini CLI, OpenCode, Aider, and Pi), keeps the Mac awake while they're working, and lets it sleep again once they're done.

Note: Belay itself isn't AI-powered - it's a companion tool that detects and reacts to agent activity rather than running any AI. Leaving that checklist item unchecked for honesty; feel free to close if that puts it outside scope.

## Checklist

- [ ] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
