### PR TITLE
Add sniff and ui-ux-suite to CI/CD & Testing Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [sniff](https://github.com/Aboudjem/sniff) — Walks a running web app in a real browser and reports 12 classes of bugs with reproduction steps, a screenshot, and a suggested fix.
+- [ui-ux-suite](https://github.com/Aboudjem/ui-ux-suite) — Audits a codebase's design for color, typography, accessibility, and layout, with a weighted 0-10 score across 12 dimensions.
 
 ---
 


### PR DESCRIPTION
Adds two AI developer tools to CI/CD & Testing Automation:

- **sniff** — walks a running web app in a real browser and reports 12 classes of bugs with reproduction steps, a screenshot, and a suggested fix.
- **ui-ux-suite** — audits a codebase's design for color, typography, accessibility, and layout, with a weighted 0-10 score across 12 dimensions.

Checklist: both entries are AI tools, developer-focused, and described in the style of neighboring rows. This supersedes my stale issue #445, which I am closing in favor of this PR.
