### PR TITLE
Add sniff and ui-ux-suite to CI/CD & Testing Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [sniff](https://github.com/Aboudjem/sniff) — Walks a running web app in a real browser and reports 12 classes of bugs with reproduction steps, a screenshot, and a suggested fix.
+- [ui-ux-suite](https://github.com/Aboudjem/ui-ux-suite) — Audits a codebase's design for color, typography, accessibility, and layout, with a weighted 0-10 score across 12 dimensions.
 
 ---
 


### PR DESCRIPTION
## Description

Adds two AI developer tools to the CI/CD & Testing Automation section:

- [sniff](https://github.com/Aboudjem/sniff) — walks a running web app in a real browser and reports 12 classes of bugs with reproduction steps, a screenshot, and a suggested fix.
- [ui-ux-suite](https://github.com/Aboudjem/ui-ux-suite) — audits a codebase's design for color, typography, accessibility, and layout, with a weighted 0-10 score across 12 dimensions.

This supersedes my stale issue #445. A first attempt (#1047) was auto-closed for missing these template headings; this one follows the template.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
