### PR TITLE
Add XiuRouter to agent infrastructure tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Tools for monitoring token usage and API costs across AI providers:
 - [aicost](https://github.com/dwylq/aicost) — Universal AI coding cost analyzer CLI. Scans Claude Code, Cursor, and GitHub Copilot usage with cache-aware pricing, HTML dashboard, and cost alerting. No API key required.
 - [CostGoat](https://costgoat.com) — Privacy-first menubar app for tracking AI agent quotas (Claude Code, Codex, Kimi, Z.ai) and LLM API costs (OpenAI, OpenRouter, Anthropic, ElevenLabs) in real-time. Also covers cloud spend and SaaS subscriptions.
 - [TokenWise](https://github.com/CodeShuX/tokenwise) — Measurement-driven model router for Claude Code. Auto-routes subtasks across Haiku/Sonnet/Opus based on task class, logs every routed task with verified $ saved to a local NDJSON, and includes an A/B test subcommand to validate cheaper tiers before trusting routing. MIT, zero telemetry, Anthropic-only.
+- [XiuRouter](https://router.xiu.ai/) — Hosted multi-model API for developer and agent tools, with protocol-specific OpenAI Responses/Chat Completions, Anthropic Messages, and Gemini GenerateContent routes, scoped API keys, and per-request usage and cost records.
 
 ---
 


### PR DESCRIPTION
## Description

Add XiuRouter to the Agent Infrastructure / Usage Analytics & Cost Tracking section as a developer-facing multi-model API service. The entry uses a concise, factual description of its protocol-specific routes, scoped keys, and request-level usage and cost records.

Submitted by XiuAI using the public product facts at https://router.xiu.ai/.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries