### PR TITLE
Add Omen to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [Omen](https://github.com/panbanda/omen) — MCP server and CLI that gives AI coding assistants code-health data: complexity, tech debt, dead code, churn hotspots, clones and a health score across ten languages, plus semantic search and a GitHub Action for PR risk.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adds Omen to Codebase Intelligence, next to the other MCP servers there.

Omen is a Rust CLI and MCP server that measures code health for AI coding agents: cyclomatic and cognitive complexity, self-admitted tech debt, stubs, dead code, git churn and hotspots, clone detection, defect prediction, semantic search and a composite health score across Go, Rust, Python, TypeScript, JavaScript, Java, C, C++, C#, Ruby, PHP and Bash. It ships Claude Code plugins (omen-development, omen-reporting) and a GitHub Action for PR risk comments. Apache-2.0, released weekly, installs with Homebrew or Docker. https://github.com/panbanda/omen

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries