### PR TITLE
Add OrcaReplay (new Debugging & Replay section under Agent Infrastructure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 
 Tools for reproducing and diagnosing agent runs after they fail:
 
-- [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) — Records a coding agent run at the process and socket boundary, then replays it offline byte-for-byte and forks it from any checkpoint onto a different model. Captures the model API, shell exit codes and timing, MCP calls, and per-turn file changes without modifying the agent. Works with Claude Code, Codex CLI, opencode, the OpenAI Agents SDK, and the Vercel AI SDK. Apache-2.0.
+- [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) — Records a coding agent run at the process and socket boundary, then replays it offline with the network off and forks it from any checkpoint onto a different model. Captures the model API, shell exit codes and timing, MCP calls, and per-turn file changes without modifying the agent. Works with Claude Code, Codex CLI, opencode, the OpenAI Agents SDK, and the Vercel AI SDK. Apache-2.0.
 
 ### Usage Analytics & Cost Tracking
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This is a curated list of AI-powered developer tools. These tools leverage AI to
   - [Multi-Agent Orchestration](#multi-agent-orchestration)
   - [Sandboxing & Isolation](#sandboxing--isolation)
   - [Configuration & Context Management](#configuration--context-management)
+  - [Debugging & Replay](#debugging--replay)
   - [Usage Analytics & Cost Tracking](#usage-analytics--cost-tracking)
 - [Specialized Tools](#specialized-tools)
   - [Git & Commit Helpers](#git--commit-helpers)
@@ -385,6 +386,12 @@ Tools that manage and sync AI agent configurations, rules, and context across ed
 - [cc-audit](https://github.com/sisyphusse1-ops/cc-audit) — Single-file Python linter that scores any `CLAUDE.md` / `AGENTS.md` against a 12-rule baseline. Flags leaked secrets (GitHub PATs, AWS keys, PayPal links), the 200-line compliance cliff, and missing project-specifics sections. Zero dependencies, JSON output for CI, MIT.
 - [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) — Drop-in governance layer for AI coding tools. Backlog-first delivery, cross-session memory, decision tracking, QA gates, and autonomous delivery daemon. Works with Claude Code, Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.
 - [intelligence-sync](https://github.com/ainova-systems/intelligence-sync) — One source of truth for AI coding rules across every IDE. Author rules, agents, and skills once in plain markdown, and the engine routes them into each tool's native format (Claude Code, Cursor, Copilot, Codex, Pi, OpenCode, AGENTS.md) with no duplication or drift. Zero dependencies, bash + awk, MIT.
+
+### Debugging & Replay
+
+Tools for reproducing and diagnosing agent runs after they fail:
+
+- [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) — Records a coding agent run at the process and socket boundary, then replays it offline byte-for-byte and forks it from any checkpoint onto a different model. Captures the model API, shell exit codes and timing, MCP calls, and per-turn file changes without modifying the agent. Works with Claude Code, Codex CLI, opencode, the OpenAI Agents SDK, and the Vercel AI SDK. Apache-2.0.
 
 ### Usage Analytics & Cost Tracking
 


### PR DESCRIPTION
## Description

Adds [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay), a record-replay debugger for coding agents, in a new `### Debugging & Replay` subsection under **Agent Infrastructure** (plus the matching Categories line).

**Why a new subsection.** The list opens by saying it covers tools for "code completion, refactoring, **debugging**, documentation" but there is currently no debugging slot. The closest existing home is *Usage Analytics & Cost Tracking*, which is explicitly about token usage and API cost — a different job. If you would rather not add a subsection, I am happy to move this into **CLI Utilities** instead; say the word and I will push the change.

**What the tool does.** `orca record claude` records a run, `orca replay last` reproduces it offline byte-for-byte with the network off, and `orca replay last --from 4 --model <other>` re-runs it from a checkpoint so the model is the only variable. Capture happens below the agent — a local proxy for the model API, a PATH shim for exit codes and stream split, a JSON-RPC tee for MCP, a shadow git index for per-turn file changes — so the agent is not modified and does not need to be yours. Works with Claude Code, Codex CLI, opencode, the OpenAI Agents SDK and the Vercel AI SDK. Apache-2.0, Node 20+.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries

Disclosure: I work on OrcaReplay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
