### PR TITLE
Add YYLO to CLI Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Lightweight command-line tools for AI-assisted commits, shell translation, and w
 - [Marmot](https://marmot.sh) — Shell-native CLI that gives agents one command shape for AI, web search, scraping, and data enrichment across many providers. Designed for Claude Code, Codex, OpenCode, and similar harnesses; composes via shell pipes.
 - [ORCH](https://github.com/oxgeneral/ORCH) — CLI runtime that coordinates Claude Code, OpenCode, Codex, and Cursor as a typed AI team. State machine (todo→review→done), auto-retry, inter-agent messaging, TUI dashboard.
 - [Octomind](https://github.com/muvon/octomind) — Session-based AI development assistant with MCP support, 7 LLM providers, and extensible architecture. Features plan-first workflow, semantic code search, and persistent memory.
+- [YYLO](https://github.com/yylo-dev/yylo) — Command-line orchestrator for coding agents and repeatable workflows. Runs tasks in dedicated worktrees with typed task, validation, merge, and release-readiness boundaries, and records receipt-backed evidence for repository changes.
 
 ---
 


### PR DESCRIPTION
## Description

Adds [YYLO](https://github.com/yylo-dev/yylo) to **CLI Utilities**, at the end of the section beside ORCH and Octomind (the closest archetypes in the list: typed CLI runtimes coordinating coding agents through state-machine workflows).

YYLO is a command-line orchestrator for coding agents and repeatable workflows. It runs each task in a dedicated git worktree with typed task, validation, merge, and release-readiness boundaries, and records receipt-backed evidence for repository changes. MIT licensed, npm-installable (`@yylo/cli`), 57★, pushed daily since January 2026.

Disclosure: I'm a maintainer of this project (self-submission; consistent with the list's history of merged author submissions such as BuilderStudio #608 and Clave #576).

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
