### PR TITLE
Add mdflow to Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [mdflow](https://github.com/yubinbin32-ops/Mdflow-Canvas) — Local-first architecture graph and MCP server that gives coding agents task-scoped project context, plans, change history, and checkpoint evidence while keeping graph state versioned with Git.
 
 ### Database & SQL
 


### PR DESCRIPTION
# Add mdflow to Codebase Intelligence

## Description

Adds mdflow to Codebase Intelligence. mdflow gives developers a visual architecture graph while MCP-compatible coding agents retrieve task-scoped project context, plans, dependencies, history, and checkpoint evidence from the same Git-versioned project graph.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
