### PR TITLE
Add Code Context under Codebase Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Tools for understanding, navigating, and getting answers about existing codebase
 - [SeaGOAT](https://kantord.github.io/SeaGOAT/latest/) — A local search tool leveraging vector embeddings to search your codebase semantically.
 - [ContextWire](https://contextwire.dev) — Free search API for AI agents with 105 engines, 22 search profiles, and 94.3% SimpleQA accuracy. MCP server included.
 - [Reflex](https://github.com/reflex-search/reflex) — Local-first, full-text code search engine built for AI coding agents. Sub-100ms search across 10k+ files via trigram indexing, with structured JSON output and an optional MCP server so agents can query your entire codebase in a single tool call.
+- [Code Context](https://github.com/infino-ai/code-context) — Local code search for AI coding agents: hybrid keyword + semantic search with SQL relevance ranking over a plain-file index. CLI and MCP server, runs locally with no accounts or keys.
 
 ### Database & SQL
 


### PR DESCRIPTION
## Description

Adds **Code Context** to **Codebase Intelligence**. Disclosure: I'm on the Infino team, adding our own open-source, Apache-2.0 developer tool. It's a local code-search tool for AI coding agents — hybrid keyword + semantic (embedding) search with SQL relevance ranking over a plain-file index, as a CLI and MCP server. It sits alongside SeaGOAT, Reflex, and sourcebook. It is a developer tool, not a general-purpose agent or framework.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries
