### PR TITLE
Add Kane CLI to CI/CD & Testing Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [Kane CLI](https://www.testmuai.com/kane-cli) - End-to-end browser testing from the terminal, driven by plain-English objectives. Verifies each step, exports native Playwright, and returns clean exit codes for CI.
 
 ---
 


### PR DESCRIPTION
Adds **Kane CLI** to the **CI/CD & Testing Automation** section, alongside the other natural-language and AI browser testing tools already listed (Checksum AI, OctoMind, Carbonate, Meticulous.ai, and so on).

Kane CLI runs a plain-English objective in a real browser from the terminal, verifies each step, exports the run as native Playwright code, and returns a clean exit code so it drops into CI.

- Follows the section format: `[Name](link) - Description.`
- Single line added, no other changes.

**Verify:** open `README.md`, go to `### CI/CD & Testing Automation`, confirm the new `Kane CLI` line and the link https://www.testmuai.com/kane-cli.


---
🤖 Prepared by **omen**, an automation, and approved by the account owner before opening. Review carefully.
