### PR TITLE
Add Kane CLI to CI/CD & Testing Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Tools that generate unit/e2e tests and integrate AI into CI/CD pipelines:
 - [CodeFlash AI](https://www.codeflash.ai/) — A CLI and CI tool for optimizing Python code using AI.
 - [Recurse ML](https://recurse.ml) — Find bugs in AI-generated code.
 - [TestDriver](https://testdriver.ai) — Cross-platform, selectorless end-to-end QA testing framework.
+- [Kane CLI](https://www.testmuai.com/kane-cli) - End-to-end browser testing from the terminal, driven by plain-English objectives. Verifies each step, exports native Playwright, and returns clean exit codes for CI.
 
 ---
 


### PR DESCRIPTION
## Description

Adds **Kane CLI** to the **CI/CD & Testing Automation** section. Kane CLI is an AI-powered, developer-focused browser testing tool: it takes a plain-English objective, runs it in a real browser from the terminal, verifies each step, exports the run as native Playwright code, and returns a clean exit code so it fits in CI. One line added, no other changes.

## Checklist

- [x] The entry is a tool that uses AI
- [x] The entry is a developer-focused tool
- [x] The description is unambiguous and clear
- [x] The description matches the style of other entries


---
🤖 Prepared by **omen**, an automation, and approved by the account owner before opening. Review carefully.
